### PR TITLE
Improve image previews for property editing

### DIFF
--- a/admin/add_property.php
+++ b/admin/add_property.php
@@ -959,12 +959,15 @@ render_sidebar('add-property');
                 </div>
               </div>
               <?php if ($isEditing && ($existingFiles['hero_banner'] ?? '') !== ''): ?>
-                <p class="form-text mt-2">
-                  Current:
+                <div class="existing-media-preview mt-2">
+                  <p class="form-text mb-2">Current:</p>
                   <a href="<?= htmlspecialchars($existingFiles['hero_banner'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">
-                    <?= htmlspecialchars(basename((string)$existingFiles['hero_banner']), ENT_QUOTES, 'UTF-8') ?>
+                    <img
+                      src="<?= htmlspecialchars($existingFiles['hero_banner'], ENT_QUOTES, 'UTF-8') ?>"
+                      alt="Current hero banner"
+                      class="existing-media-preview-img">
                   </a>
-                </p>
+                </div>
               <?php endif; ?>
             </div>
             <div class="col-lg-4">
@@ -1008,17 +1011,22 @@ render_sidebar('add-property');
                 </div>
               </div>
               <?php if ($isEditing && $existingGalleryPaths !== []): ?>
-                <div class="mt-2">
-                  <p class="form-text mb-1">Current gallery images:</p>
-                  <ul class="mb-0 ps-3 small">
-                    <?php foreach ($existingGalleryPaths as $galleryPath): ?>
-                      <li>
-                        <a href="<?= htmlspecialchars($galleryPath, ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">
-                          <?= htmlspecialchars(basename((string)$galleryPath), ENT_QUOTES, 'UTF-8') ?>
-                        </a>
-                      </li>
+                <div class="existing-gallery-preview mt-2">
+                  <p class="form-text mb-2">Current gallery images:</p>
+                  <div class="gallery-preview-grid">
+                    <?php foreach ($existingGalleryPaths as $index => $galleryPath): ?>
+                      <a
+                        href="<?= htmlspecialchars($galleryPath, ENT_QUOTES, 'UTF-8') ?>"
+                        target="_blank"
+                        rel="noopener"
+                        class="gallery-preview-link">
+                        <img
+                          src="<?= htmlspecialchars($galleryPath, ENT_QUOTES, 'UTF-8') ?>"
+                          alt="Gallery image <?= (int)($index + 1) ?>"
+                          class="gallery-preview-img">
+                      </a>
                     <?php endforeach; ?>
-                  </ul>
+                  </div>
                 </div>
               <?php endif; ?>
             </div>
@@ -1038,12 +1046,15 @@ render_sidebar('add-property');
                 </div>
               </div>
               <?php if ($isEditing && ($existingFiles['developer_logo'] ?? '') !== ''): ?>
-                <p class="form-text mt-2">
-                  Current:
+                <div class="existing-media-preview mt-2">
+                  <p class="form-text mb-2">Current:</p>
                   <a href="<?= htmlspecialchars($existingFiles['developer_logo'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">
-                    <?= htmlspecialchars(basename((string)$existingFiles['developer_logo']), ENT_QUOTES, 'UTF-8') ?>
+                    <img
+                      src="<?= htmlspecialchars($existingFiles['developer_logo'], ENT_QUOTES, 'UTF-8') ?>"
+                      alt="Current developer logo"
+                      class="existing-media-preview-img">
                   </a>
-                </p>
+                </div>
               <?php endif; ?>
             </div>
             <div class="col-lg-8">
@@ -1062,12 +1073,15 @@ render_sidebar('add-property');
                 </div>
               </div>
               <?php if ($isEditing && ($existingFiles['permit_barcode'] ?? '') !== ''): ?>
-                <p class="form-text mt-2">
-                  Current:
+                <div class="existing-media-preview mt-2">
+                  <p class="form-text mb-2">Current:</p>
                   <a href="<?= htmlspecialchars($existingFiles['permit_barcode'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">
-                    <?= htmlspecialchars(basename((string)$existingFiles['permit_barcode']), ENT_QUOTES, 'UTF-8') ?>
+                    <img
+                      src="<?= htmlspecialchars($existingFiles['permit_barcode'], ENT_QUOTES, 'UTF-8') ?>"
+                      alt="Current permit barcode"
+                      class="existing-media-preview-img">
                   </a>
-                </p>
+                </div>
               <?php endif; ?>
             </div>
       </div>

--- a/admin/all_properties.php
+++ b/admin/all_properties.php
@@ -220,7 +220,10 @@ render_head('All Properties', 'dashboard-body');
                       </td>
                       <td class="text-end">
                         <div class="btn-group" role="group" aria-label="Property Actions">
-                          <a class="btn btn-sm btn-outline-primary" href="add_property.php?edit=<?= urlencode((string)$property['id']); ?>" title="Edit">
+                          <a
+                            class="btn btn-sm btn-outline-primary"
+                            href="<?= 'add_property.php?edit=' . urlencode((string)$property['id']); ?>"
+                            title="Edit">
                             <i class="bi bi-pencil-square"></i>
                           </a>
                           <form method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this property?');">

--- a/admin/assets/css/style.css
+++ b/admin/assets/css/style.css
@@ -239,3 +239,52 @@ body {
   margin-bottom: 0;
   color: #64748b;
 }
+
+.existing-media-preview {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  display: inline-block;
+  padding: 12px;
+}
+
+.existing-media-preview-img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+}
+
+.existing-gallery-preview {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.gallery-preview-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.gallery-preview-link {
+  display: inline-block;
+}
+
+.gallery-preview-img {
+  width: 120px;
+  height: 90px;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gallery-preview-link:hover .gallery-preview-img {
+  transform: scale(1.03);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
+}
+


### PR DESCRIPTION
## Summary
- ensure the edit action links to the add property form with the correct query string
- replace existing file name links with inline previews for uploaded images in the property form
- add styling to support the new media preview components

## Testing
- php -l admin/add_property.php
- php -l admin/all_properties.php

------
https://chatgpt.com/codex/tasks/task_e_68dcd308e118832a97a175b5d6ac77f1