### PR TITLE
Improve admin sidebar dropdown behavior

### DIFF
--- a/admin/assets/css/style.css
+++ b/admin/assets/css/style.css
@@ -64,10 +64,15 @@ body {
 }
 
 .sidebar .nav-submenu {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
   padding: 4px 0 8px;
+}
+
+.sidebar .nav-submenu.collapse {
+  transition: height 0.25s ease;
+}
+
+.sidebar .nav-submenu.collapse:not(.show) {
+  display: none;
 }
 
 .sidebar .nav-sublink {
@@ -79,6 +84,10 @@ body {
   padding: 0.4rem 0.75rem 0.4rem 2.25rem;
   font-size: 0.95rem;
   transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sidebar .nav-sublink + .nav-sublink {
+  margin-top: 4px;
 }
 
 .sidebar .nav-sublink .submenu-indicator {

--- a/admin/assets/js/sidebar.js
+++ b/admin/assets/js/sidebar.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const sidebar = document.querySelector('.sidebar');
+  if (!sidebar) {
+    return;
+  }
+
+  const toggles = sidebar.querySelectorAll('.menu-toggle[data-bs-target]');
+  toggles.forEach((toggle) => {
+    const targetSelector = toggle.getAttribute('data-bs-target');
+    if (!targetSelector) {
+      return;
+    }
+
+    const target = document.querySelector(targetSelector);
+    if (!target) {
+      return;
+    }
+
+    target.addEventListener('show.bs.collapse', () => {
+      toggle.classList.add('active');
+      toggle.setAttribute('aria-expanded', 'true');
+    });
+
+    target.addEventListener('hide.bs.collapse', () => {
+      toggle.classList.remove('active');
+      toggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+});

--- a/admin/includes/render.php
+++ b/admin/includes/render.php
@@ -98,7 +98,8 @@ function render_sidebar(string $active): void
   echo '</form>';
   echo '</div>';
 
-  echo '<nav class="nav flex-column gap-1">';
+  $navId = 'sidebar-nav';
+  echo '<nav id="' . $navId . '" class="nav flex-column gap-1">';
   $index = 0;
   foreach ($menu as $item) {
     $index++;
@@ -136,7 +137,7 @@ function render_sidebar(string $active): void
       $collapseClass .= ' show';
     }
 
-    echo '<div id="' . htmlspecialchars($collapseId, ENT_QUOTES, 'UTF-8') . '" class="' . $collapseClass . '">';
+    echo '<div id="' . htmlspecialchars($collapseId, ENT_QUOTES, 'UTF-8') . '" class="' . $collapseClass . '" data-bs-parent="#' . $navId . '">';
     foreach ($item['items'] as $childKey => $child) {
       $childActive = $childKey === $active ? ' active' : '';
       $href = htmlspecialchars($child['href'], ENT_QUOTES, 'UTF-8');
@@ -172,6 +173,7 @@ function render_footer(bool $includeECharts = false, bool $includeChartJs = fals
 
 
   echo "\n<script src=\"assets/js/table-tooltips.js\"></script>";
+  echo "\n<script src=\"assets/js/sidebar.js\"></script>";
   echo '</body></html>';
 }
 


### PR DESCRIPTION
## Summary
- ensure the admin sidebar collapse menu uses a shared parent so only one dropdown stays open at a time
- tweak sidebar styles for smoother collapse animations and consistent spacing
- add a sidebar script to keep toggle button state in sync with collapse events

## Testing
- php -l admin/includes/render.php

------
https://chatgpt.com/codex/tasks/task_e_68e0bc0a44c8832a8c990aee92f06d24