### PR TITLE
Implement buy properties listing and details pages

### DIFF
--- a/buy-properties-details.php
+++ b/buy-properties-details.php
@@ -1,0 +1,2123 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/config.php';
+
+$propertyId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+
+if ($propertyId <= 0) {
+    http_response_code(404);
+    echo 'Property not found.';
+    exit;
+}
+
+try {
+    $pdo = hh_db();
+    $stmt = $pdo->prepare('SELECT * FROM buy_properties_list WHERE id = :id LIMIT 1');
+    $stmt->execute([':id' => $propertyId]);
+    $property = $stmt->fetch();
+} catch (Throwable $e) {
+    $property = false;
+}
+
+if (!$property) {
+    http_response_code(404);
+    echo 'Property not found.';
+    exit;
+}
+
+$decodeList = static function (?string $json): array {
+    if (!$json) {
+        return [];
+    }
+
+    try {
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+    } catch (Throwable $e) {
+        return [];
+    }
+
+    if (!is_array($decoded)) {
+        return [];
+    }
+
+    return array_values(array_filter(
+        $decoded,
+        static fn($value): bool => is_string($value) && $value !== '' || (is_array($value) && !empty(array_filter($value, static fn($v) => $v !== '' && $v !== null)))
+    ));
+};
+
+$extractParagraphs = static function ($value): array {
+    if (!is_string($value)) {
+        return [];
+    }
+
+    $value = trim($value);
+    if ($value === '') {
+        return [];
+    }
+
+    $decoded = html_entity_decode($value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+    $withBreaks = preg_replace(
+        [
+            '#<\s*br\s*/?>#i',
+            '#<\s*/p\s*>#i',
+            '#<\s*/div\s*>#i',
+            '#<\s*/li\s*>#i',
+            '#<\s*/h[1-6]\s*>#i',
+            '#<\s*/tr\s*>#i',
+            '#<\s*/table\s*>#i',
+            '#<\s*/ul\s*>#i',
+            '#<\s*/ol\s*>#i',
+        ],
+        "\n",
+        $decoded
+    );
+
+    $withBreaks = preg_replace('#<\s*li\b[^>]*>#i', '- ', $withBreaks);
+    $withBreaks = preg_replace('#<\s*(p|div|h[1-6]|tr|td|th)\b[^>]*>#i', '', $withBreaks);
+
+    $withoutTags = strip_tags($withBreaks);
+    $normalized = preg_replace("/\r\n|\r|\n/", "\n", $withoutTags);
+
+    return array_values(array_filter(array_map(
+        static function (string $paragraph): string {
+            $paragraph = trim(preg_replace('/\s+/u', ' ', $paragraph));
+            return $paragraph;
+        },
+        preg_split("/\n+/", $normalized) ?: []
+    ), static fn($paragraph): bool => $paragraph !== ''));
+};
+
+$uploadsBasePath = 'admin/assets/uploads/properties/';
+$legacyUploadsPrefix = 'assets/uploads/properties/';
+$normalizeImagePath = static function (?string $path) use ($uploadsBasePath, $legacyUploadsPrefix): ?string {
+    if (!is_string($path)) {
+        return null;
+    }
+
+    $path = trim(str_replace('\\', '/', $path));
+    if ($path === '') {
+        return null;
+    }
+
+    if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://') || str_starts_with($path, '//')) {
+        return $path;
+    }
+
+    $path = ltrim($path, '/');
+
+    if (str_starts_with($path, $uploadsBasePath)) {
+        return $path;
+    }
+
+    if (str_starts_with($path, $legacyUploadsPrefix)) {
+        return $uploadsBasePath . substr($path, strlen($legacyUploadsPrefix));
+    }
+
+    return $uploadsBasePath . $path;
+};
+
+$heroBanner = is_string($property['hero_banner'] ?? '') && $property['hero_banner'] !== ''
+    ? $normalizeImagePath($property['hero_banner'])
+    : null;
+
+$galleryImages = array_values(array_filter(
+    array_map(
+        fn($path): ?string => $normalizeImagePath(is_string($path) ? $path : null),
+        $decodeList($property['gallery_images'] ?? null)
+    )
+));
+
+if (!$galleryImages && $heroBanner) {
+    $galleryImages[] = $heroBanner;
+}
+
+$primaryImage = $heroBanner ?? ($galleryImages[0] ?? 'assets/images/properties-listing/breez-by-danube-list.webp');
+
+if (!$galleryImages) {
+    $galleryImages[] = $primaryImage;
+}
+
+$galleryCount = count($galleryImages);
+
+$floorPlansRaw = $decodeList($property['floor_plans'] ?? null);
+$floorPlans = [];
+foreach ($floorPlansRaw as $plan) {
+    if (!is_array($plan)) {
+        continue;
+    }
+
+    $floorPlans[] = [
+        'title' => isset($plan['title']) && is_string($plan['title']) ? trim($plan['title']) : '',
+        'area' => isset($plan['area']) && is_string($plan['area']) ? trim($plan['area']) : '',
+        'price' => isset($plan['price']) && is_string($plan['price']) ? trim($plan['price']) : '',
+        'file' => isset($plan['file']) && is_string($plan['file'])
+            ? ($normalizeImagePath($plan['file']) ?? trim($plan['file']))
+            : '',
+    ];
+}
+
+$locationAccessRaw = $decodeList($property['location_accessibility'] ?? null);
+$locationAccess = [];
+foreach ($locationAccessRaw as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+
+    $landmark = isset($item['landmark_name']) && is_string($item['landmark_name']) ? trim($item['landmark_name']) : '';
+    $distance = isset($item['distance_time']) && is_string($item['distance_time']) ? trim($item['distance_time']) : '';
+    $category = isset($item['category']) && is_string($item['category']) ? trim($item['category']) : '';
+
+    if ($landmark === '' && $distance === '' && $category === '') {
+        continue;
+    }
+
+    $locationAccess[] = [
+        'landmark' => $landmark,
+        'distance' => $distance,
+        'category' => $category,
+    ];
+}
+
+if (!$locationAccess) {
+    $landmark = trim((string) ($property['landmark_name'] ?? ''));
+    $distance = trim((string) ($property['distance_time'] ?? ''));
+    $category = trim((string) ($property['category'] ?? ''));
+
+    if ($landmark !== '' || $distance !== '' || $category !== '') {
+        $locationAccess[] = [
+            'landmark' => $landmark,
+            'distance' => $distance,
+            'category' => $category,
+        ];
+    }
+}
+
+$completionDate = null;
+if (!empty($property['completion_date'])) {
+    try {
+        $completionDate = (new DateTime((string) $property['completion_date']))->format('F Y');
+    } catch (Throwable $e) {
+        $completionDate = trim((string) $property['completion_date']);
+    }
+}
+
+$startingPrice = trim((string) ($property['starting_price'] ?? ''));
+$startingPriceDisplay = $startingPrice;
+if ($startingPriceDisplay !== '' && stripos($startingPriceDisplay, 'aed') === false) {
+    $startingPriceDisplay = 'AED ' . $startingPriceDisplay;
+}
+$startingPriceCurrency = '';
+$startingPriceValue = '';
+if ($startingPriceDisplay !== '') {
+    if (stripos($startingPriceDisplay, 'aed') === 0) {
+        $startingPriceCurrency = 'AED';
+        $startingPriceValue = trim(substr($startingPriceDisplay, 3));
+    } else {
+        $startingPriceValue = $startingPriceDisplay;
+    }
+}
+
+$developerLogo = is_string($property['developer_logo'] ?? '') && $property['developer_logo'] !== ''
+    ? $normalizeImagePath($property['developer_logo'])
+    : null;
+
+$permitBarcode = is_string($property['permit_barcode'] ?? '') && $property['permit_barcode'] !== ''
+    ? $normalizeImagePath($property['permit_barcode'])
+    : null;
+
+$videoLink = trim((string) ($property['video_link'] ?? ''));
+$locationMap = trim((string) ($property['location_map'] ?? ''));
+$brochure = trim((string) ($property['brochure'] ?? ''));
+
+$featureItems = array_values(array_filter([
+    $property['project_status'] ?? null,
+    $property['property_type'] ? 'Property Type: ' . $property['property_type'] : null,
+    $property['bedroom'] ? 'Bedrooms: ' . $property['bedroom'] : null,
+    $property['bathroom'] ? 'Bathrooms: ' . $property['bathroom'] : null,
+    $property['parking'] ? 'Parking: ' . $property['parking'] : null,
+    $property['total_area'] ? 'Total Area: ' . $property['total_area'] : null,
+    $completionDate ? 'Completion: ' . $completionDate : null,
+]));
+
+if (!empty($property['project_name'])) {
+    array_unshift($featureItems, 'Project Name: ' . trim((string) $property['project_name']));
+}
+
+$amenitiesList = [];
+$amenitiesRaw = $decodeList($property['amenities'] ?? null);
+foreach ($amenitiesRaw as $amenity) {
+    if (is_string($amenity)) {
+        $amenity = trim($amenity);
+        if ($amenity !== '') {
+            $amenitiesList[] = $amenity;
+        }
+    }
+}
+
+$resolveAmenityIcon = static function (string $label): string {
+    $normalized = trim($label);
+    if ($normalized === '') {
+        return 'bi bi-check-circle';
+    }
+
+    $lower = function_exists('mb_strtolower') ? mb_strtolower($normalized) : strtolower($normalized);
+
+    $iconMap = [
+        ['keywords' => ['pool', 'swim'], 'icon' => 'bi bi-water'],
+        ['keywords' => ['gym', 'fitness'], 'icon' => 'bi bi-activity'],
+        ['keywords' => ['parking'], 'icon' => 'bi bi-p-square'],
+        ['keywords' => ['security', 'guard'], 'icon' => 'bi bi-shield-check'],
+        ['keywords' => ['park', 'garden', 'green'], 'icon' => 'bi bi-tree'],
+        ['keywords' => ['bbq', 'barbecue', 'grill'], 'icon' => 'bi bi-fire'],
+        ['keywords' => ['play area', 'playground', 'kids', 'children'], 'icon' => 'bi bi-emoji-smile'],
+        ['keywords' => ['spa', 'wellness'], 'icon' => 'bi bi-flower1'],
+        ['keywords' => ['beach'], 'icon' => 'bi bi-sun'],
+        ['keywords' => ['shopping', 'mall', 'retail'], 'icon' => 'bi bi-bag'],
+        ['keywords' => ['school', 'education'], 'icon' => 'bi bi-mortarboard'],
+        ['keywords' => ['hospital', 'clinic', 'medical'], 'icon' => 'bi bi-hospital'],
+        ['keywords' => ['wifi', 'internet'], 'icon' => 'bi bi-wifi'],
+        ['keywords' => ['clubhouse', 'club house', 'community hall'], 'icon' => 'bi bi-house'],
+        ['keywords' => ['lobby'], 'icon' => 'bi bi-door-open'],
+        ['keywords' => ['air condition', 'ac'], 'icon' => 'bi bi-snow'],
+        ['keywords' => ['sauna', 'steam'], 'icon' => 'bi bi-thermometer-half'],
+        ['keywords' => ['cinema', 'theatre', 'theater'], 'icon' => 'bi bi-film'],
+        ['keywords' => ['tennis'], 'icon' => 'bi bi-tennis-ball'],
+        ['keywords' => ['basketball'], 'icon' => 'fa-regular fa-person-basketball'],
+        ['keywords' => ['golf'], 'icon' => 'bi bi-flag'],
+        ['keywords' => ['jogging', 'running', 'cycle'], 'icon' => 'bi bi-person-running'],
+        ['keywords' => ['elevator', 'lift'], 'icon' => 'bi bi-arrow-down-up'],
+    ];
+
+    foreach ($iconMap as $entry) {
+        foreach ($entry['keywords'] as $keyword) {
+            if ($keyword !== '' && str_contains($lower, $keyword)) {
+                return $entry['icon'];
+            }
+        }
+    }
+
+    return 'bi bi-check-circle';
+};
+
+$aboutProjectParagraphs = $extractParagraphs($property['about_project'] ?? null);
+
+$aboutDeveloperParagraphs = $extractParagraphs($property['about_developer'] ?? null);
+
+$specItems = [];
+if (!empty($property['bedroom'])) {
+    $specItems[] = ['icon' => 'assets/icons/bed.png', 'label' => trim((string) $property['bedroom']), 'suffix' => ' Bedrooms'];
+}
+if (!empty($property['bathroom'])) {
+    $specItems[] = ['icon' => 'assets/icons/bathroom.png', 'label' => trim((string) $property['bathroom']), 'suffix' => ' Bathrooms'];
+}
+if (!empty($property['parking'])) {
+    $specItems[] = ['icon' => 'assets/icons/parking.png', 'label' => trim((string) $property['parking']), 'suffix' => ' Parking'];
+}
+if (!empty($property['total_area'])) {
+    $specItems[] = ['icon' => 'assets/icons/area.png', 'label' => trim((string) $property['total_area']), 'suffix' => ''];
+}
+if ($completionDate) {
+    $specItems[] = ['icon' => 'assets/icons/calendar.png', 'label' => $completionDate, 'suffix' => ' Completion'];
+}
+
+$investmentHighlights = array_filter([
+    ['label' => 'ROI Potential', 'value' => $property['roi_potential'] ?? null, 'note' => ''],
+    ['label' => 'Capital Growth', 'value' => $property['capital_growth'] ?? null, 'note' => ''],
+    ['label' => 'Occupancy Rate', 'value' => $property['occupancy_rate'] ?? null, 'note' => ''],
+    ['label' => 'Resale Value', 'value' => $property['resale_value'] ?? null, 'note' => ''],
+], static fn($item) => isset($item['value']) && trim((string) $item['value']) !== '');
+
+$paymentSchedule = array_filter([
+    ['title' => 'Booking Amount', 'percentage' => $property['booking_percentage'] ?? null, 'amount' => $property['booking_amount'] ?? null],
+    ['title' => 'During Construction', 'percentage' => $property['during_construction_percentage'] ?? null, 'amount' => $property['during_construction_amount'] ?? null],
+    ['title' => 'On Handover', 'percentage' => $property['handover_percentage'] ?? null, 'amount' => $property['handover_amount'] ?? null],
+], static fn($item) => (isset($item['percentage']) && trim((string) $item['percentage']) !== '') || (isset($item['amount']) && trim((string) $item['amount']) !== ''));
+
+$propertyTitle = trim((string) ($property['property_title'] ?? ''));
+$titleText = $propertyTitle !== '' ? $propertyTitle : 'Buy Property Details';
+$metaTitle = trim((string) ($property['meta_title'] ?? ''));
+if ($metaTitle === '') {
+    $metaTitle = $titleText;
+}
+$metaKeywords = trim((string) ($property['meta_keywords'] ?? ''));
+$metaDescription = trim((string) ($property['meta_description'] ?? ''));
+
+$developerStats = array_values(array_filter([
+    ['label' => 'Established', 'value' => $property['developer_established'] ?? null],
+    ['label' => 'Completed Projects', 'value' => $property['completed_projects'] ?? null],
+    ['label' => 'International Awards', 'value' => $property['international_awards'] ?? null],
+    ['label' => 'On-Time Delivery', 'value' => $property['on_time_delivery'] ?? null],
+], static fn($stat) => isset($stat['value']) && trim((string) $stat['value']) !== ''));
+?>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="shortcut icon" href="assets/images/logo/favicon.svg" type="image/x-icon">
+    <title><?= htmlspecialchars($metaTitle, ENT_QUOTES, 'UTF-8') ?></title>
+    <?php if ($metaDescription !== ''): ?>
+        <meta name="description" content="<?= htmlspecialchars($metaDescription, ENT_QUOTES, 'UTF-8') ?>">
+    <?php endif; ?>
+    <?php if ($metaKeywords !== ''): ?>
+        <meta name="keywords" content="<?= htmlspecialchars($metaKeywords, ENT_QUOTES, 'UTF-8') ?>">
+    <?php endif; ?>
+    <link rel="stylesheet" href="assets/vendors/bootstrap/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/country-select-js@2.0.1/build/css/countrySelect.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/18.2.1/css/intlTelInput.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css">
+    <link rel="stylesheet" href="assets/css/properties.css">
+</head>
+
+<body>
+
+
+    <!-- parent: .hh-property-hero -->
+    <div class="hh-property-hero " data-animation-in="animate__fadeIn" data-animation-out="animate__fadeOut"
+        style="background-image: url('<?= htmlspecialchars($primaryImage, ENT_QUOTES, 'UTF-8') ?>');">
+        <!-- Top bar fixed at top of hero -->
+        <div class="hh-property-hero-top">
+            <a href="buy-properties.php" class="hh-property-hero-back">← Back to Buy Listings</a>
+            <div class="hh-property-hero-top-actions">
+                <button type="button" class="hh-primarypill" onclick="openPopup()"><img width="14"
+                        src="assets/flaticons/phone.png" alt=""> Contact Agent</button>
+            </div>
+        </div>
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <!-- Info block -->
+                    <div class="hh-property-hero-info ">
+                        <?php if (!empty($property['project_status']) || !empty($property['property_type'])): ?>
+                            <div class="hh-property-hero-tags">
+                                <?php if (!empty($property['project_status'])): ?>
+                                    <span
+                                        class="green"><?= htmlspecialchars($property['project_status'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <?php endif; ?>
+                                <?php if (!empty($property['property_type'])): ?>
+                                    <span><?= htmlspecialchars($property['property_type'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <?php endif; ?>
+                            </div>
+                        <?php endif; ?>
+                        <h1><?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?></h1>
+                        <?php if (!empty($property['project_name'])): ?>
+                            <p class="text-white fw-semibold mb-2 d-none">Project Name:
+                                <?= htmlspecialchars($property['project_name'], ENT_QUOTES, 'UTF-8') ?></p>
+                        <?php endif; ?>
+                        <?php if (!empty($property['property_location'])): ?>
+                            <div class="hh-property-hero-loc"><img src="assets/icons/location.png" alt=""
+                                    width="16"><?= htmlspecialchars($property['property_location'], ENT_QUOTES, 'UTF-8') ?>
+                            </div>
+                        <?php endif; ?>
+                        <!-- <?php if ($startingPriceValue !== ''): ?>
+                            <div class="hh-property-hero-price">
+                                <?php if ($startingPriceCurrency !== ''): ?>
+                                    <span
+                                        class="AED"><?= htmlspecialchars($startingPriceCurrency, ENT_QUOTES, 'UTF-8') ?></span>
+                                    <?= htmlspecialchars($startingPriceValue, ENT_QUOTES, 'UTF-8') ?>
+                                <?php else: ?>
+                                    <?= htmlspecialchars($startingPriceValue, ENT_QUOTES, 'UTF-8') ?>
+                                <?php endif; ?>
+                                <span>Starting from</span>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ($specItems): ?>
+                            <ul class="hh-property-hero-specs">
+                                <?php foreach ($specItems as $spec): ?>
+                                    <li>
+                                        <img src="<?= htmlspecialchars($spec['icon'], ENT_QUOTES, 'UTF-8') ?>" alt=""
+                                            width="16">
+                                        <?= htmlspecialchars(trim($spec['label'] . ' ' . $spec['suffix']), ENT_QUOTES, 'UTF-8') ?>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?> -->
+                    </div>
+
+                    <!-- Bottom CTA buttons -->
+                    <div class="hh-property-hero-ctas " data-animation-in="animate__flipInX"
+                        data-animation-out="animate__flipOutX">
+                        <button type="button" class="cta-solid" onclick="openPopup()">Enquire Now</button>
+                        <button type="button" class="cta-outline" onclick="Brochurepopup()">Download Brochure</button>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <section class="info-section">
+        <div class="container-fluid px-4">
+            <div class="row g-3">
+                <?php if ($startingPriceValue !== ''): ?>
+                    <div class="col-6 col-md-2">
+                        <div class="info-card p-4 text-center h-100 text-white">
+                            <img src="assets/icons/dollar.png" alt="Price" width="28" class="mb-2">
+                            <div class="details">
+                                Starting From -
+                                <?= htmlspecialchars(trim($startingPriceCurrency . ' ' . $startingPriceValue), ENT_QUOTES, 'UTF-8') ?>
+
+                            </div>
+                        </div>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($specItems): ?>
+                    <?php foreach ($specItems as $spec): ?>
+                        <div class="col-6 col-md-2">
+                            <div class="info-card p-4 text-center h-100 text-white">
+                                <img src="<?= htmlspecialchars($spec['icon'], ENT_QUOTES, 'UTF-8') ?>"
+                                    alt="icon" width="28" class="mb-2">
+                                <div class="details">
+                                    <?= htmlspecialchars(trim($spec['label']), ENT_QUOTES, 'UTF-8') ?>
+                                    -
+                                    <?= htmlspecialchars(trim($spec['suffix']), ENT_QUOTES, 'UTF-8') ?>
+                                </div>
+                                <!-- <div class="small mt-1 details">
+                                    
+                                </div> -->
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </section>
+
+
+
+    <!-- parent: .hh-gallery-01 -->
+    <div class="hh-gallery-01 ">
+        <div class="container">
+
+            <!-- Header -->
+            <div class="row">
+                <div class="col-12">
+                    <div class="hh-gallery-01-head " data-animation-in="animate__fadeInDown"
+                        data-animation-out="animate__fadeOutUp">
+                        <h3>Property Gallery</h3>
+                        <div class="hh-gallery-01-head-actions">
+                            <button type="button" class="ghost" data-action="view-all">
+                                <svg width="18" height="18" viewBox="0 0 24 24">
+                                    <path d="M4 5h7v6H4zM13 5h7v6h-7zM4 13h7v6H4zM13 13h7v6h-7z" fill="currentColor" />
+                                </svg>
+                                View All (<?= $galleryCount ?>)
+                            </button>
+                            <?php if ($videoLink !== ''): ?>
+                                <button type="button" class="solid" data-action="video"
+                                    data-video="<?= htmlspecialchars($videoLink, ENT_QUOTES, 'UTF-8') ?>">
+                                    <svg width="18" height="18" viewBox="0 0 24 24">
+                                        <path d="M4 5h11a2 2 0 0 1 2 2v1.5l3-2v11l-3-2V17a2 2 0 0 1-2 2H4z"
+                                            fill="currentColor" />
+                                    </svg>
+                                    Video Tour
+                                </button>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Gallery + Agent -->
+            <div class="row">
+                <!-- Left: Gallery -->
+                <div class="col-12 col-lg-8">
+                    <div class="hh-gallery-01-wrap " data-animation-in="animate__fadeInLeft"
+                        data-animation-out="animate__fadeOutLeft">
+
+                        <!-- Main swiper -->
+                        <div class="swiper hh-gallery-01-main">
+                            <div class="swiper-wrapper">
+                                <?php if ($galleryImages): ?>
+                                    <?php foreach ($galleryImages as $image): ?>
+                                        <div class="swiper-slide">
+                                            <img src="<?= htmlspecialchars($image, ENT_QUOTES, 'UTF-8') ?>"
+                                                alt="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                                        </div>
+                                    <?php endforeach; ?>
+                                <?php else: ?>
+                                    <div class="swiper-slide">
+                                    <img src="assets/images/properties-listing/breez-by-danube-list.webp" alt="Placeholder image">
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+
+                            <!-- overlay controls -->
+                            <button type="button" class="nav prev" aria-label="Previous"></button>
+                            <button type="button" class="nav next" aria-label="Next"></button>
+                            <button type="button" class="fullscreen" aria-label="Full screen">
+                                <svg width="18" height="18" viewBox="0 0 24 24">
+                                    <path
+                                        d="M9 5H5v4H3V3h6v2zm6-2h6v6h-2V5h-4V3zM5 15H3v6h6v-2H5v-4zm16 0v6h-6v-2h4v-4h2z"
+                                        fill="currentColor" />
+                                </svg>
+                            </button>
+                            <div class="fraction"><span><?= $galleryCount > 0 ? 1 : 0 ?></span> of
+                                <span><?= $galleryCount ?></span>
+                            </div>
+                            <div class="progress"><i
+                                    style="width: <?= $galleryCount > 0 ? 100 / max($galleryCount, 1) : 0 ?>%"></i>
+                            </div>
+                        </div>
+
+                        <!-- Thumbs swiper -->
+                        <div class="swiper hh-gallery-01-thumbs">
+                            <div class="swiper-wrapper">
+                                <?php if ($galleryImages): ?>
+                                    <?php foreach ($galleryImages as $image): ?>
+                                        <div class="swiper-slide"><img
+                                                src="<?= htmlspecialchars($image, ENT_QUOTES, 'UTF-8') ?>" alt=""></div>
+                                    <?php endforeach; ?>
+                                <?php else: ?>
+                                    <div class="swiper-slide"><img src="assets/images/properties-listing/breez-by-danube-list.webp" alt="">
+                                    </div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Right: Agent panel -->
+                <div class="col-12 col-lg-4">
+                    <aside class="hh-gallery-01-agent " data-animation-in="animate__flipInY"
+                        data-animation-out="animate__flipOutY">
+                        <div class="card-head">
+                            <div class="avatar">
+                                <svg width="28" height="28" viewBox="0 0 24 24">
+                                    <path
+                                        d="M12 2a5 5 0 1 1 0 10A5 5 0 0 1 12 2Zm0 12c4.2 0 8 2.1 8 5v3H4v-3c0-2.9 3.8-5 8-5Z"
+                                        fill="#fff" />
+                                </svg>
+                            </div>
+                            <div class="info">
+                                <strong>Sarah Al-Mansouri</strong>
+                                <span>Senior Property Consultant</span>
+                                <em>★★★★★ · 5.0 Rating</em>
+                            </div>
+                        </div>
+
+                        <div class="cta-row">
+                            <button type="button" class="call" onclick="window.location.href='tel:+971 42554683'">
+                                <img src="assets/flaticons/phone.png" alt="" width="16">
+                                Call
+                            </button>
+                            <button type="button" class="wa"
+                                onclick="window.open('https://wa.me/97142554683','_blank')">
+                                <img src="assets/flaticons/whatsapp.png" alt="WhatsApp" width="20">
+                                WhatsApp
+                            </button>
+
+                        </div>
+
+                        <button type="button" class="ghost-wide" onclick="openPopup()">
+                            <img src="assets/icons/calendar.png" alt="" width="16">
+                            Schedule Viewing
+                        </button>
+
+                        <div class="actions">
+                            <!-- <button type="button">
+                                <img src="assets/icons/video-call.png" alt="" width="20">
+                                3D Virtual Tour
+                            </button> -->
+                            <button type="button" onclick="Brochurepopup()">
+                                <img src="assets/icons/brochure-download.png" alt="" width="20">
+                                Download Brochure
+                            </button>
+                            <button type="button" onclick="openPopup()">
+                                <img src="assets/icons/floorplan.png" alt="" width="20">
+                                View Floor Plans
+                            </button>
+                        </div>
+                    </aside>
+                </div>
+            </div>
+        </div>
+
+        <!-- Lightbox (custom, no extra lib) -->
+        <div class="hh-gallery-01-lightbox" aria-hidden="true">
+            <button type="button" class="lb-close" aria-label="Close">×</button>
+            <button type="button" class="lb-prev" aria-label="Previous"></button>
+            <img alt="">
+            <button type="button" class="lb-next" aria-label="Next"></button>
+        </div>
+    </div>
+
+    <!-- parent: .hh-details-01 -->
+    <div class="hh-details-01 ">
+        <div class="container">
+            <!-- Body -->
+            <div class="row">
+                <div class="col-12 col-lg-8">
+                    <nav class="hh-tabs " data-animation-in="animate__fadeInDown"
+                        data-animation-out="animate__fadeOutUp" role="tablist" aria-label="Property details tabs">
+                        <ul>
+                            <li>
+                                <button id="hh-tab-overview-btn" type="button" class="active" role="tab"
+                                    aria-selected="true" aria-controls="hh-tab-overview" data-bs-toggle="tab"
+                                    data-bs-target="#hh-tab-overview">
+                                    Overview
+                                </button>
+                            </li>
+                            <li>
+                                <button id="hh-tab-features-btn" type="button" role="tab" aria-selected="false"
+                                    aria-controls="hh-tab-features" data-bs-toggle="tab"
+                                    data-bs-target="#hh-tab-features">
+                                    Key Features & Amenities
+                                </button>
+                            </li>
+                            <li>
+                                <button id="hh-tab-floor-btn" type="button" role="tab" aria-selected="false"
+                                    aria-controls="hh-tab-floor" data-bs-toggle="tab" data-bs-target="#hh-tab-floor">
+                                    Floor Plan
+                                </button>
+                            </li>
+                            <li>
+                                <button id="hh-tab-developer-btn" type="button" role="tab" aria-selected="false"
+                                    aria-controls="hh-tab-developer" data-bs-toggle="tab"
+                                    data-bs-target="#hh-tab-developer">
+                                    Developer
+                                </button>
+                            </li>
+                        </ul>
+                    </nav>
+
+                    <!-- Bootstrap required wrapper -->
+                    <div class="tab-content">
+
+                        <!-- Overview -->
+                        <div id="hh-tab-overview" class="tab-pane fade show active" role="tabpanel"
+                            aria-labelledby="hh-tab-overview-btn">
+                            <div class="container-fluid">
+                                <div class="row">
+                                    <div class="col-lg-12 p-0">
+                                        <div class="project-overview ">
+                                            <div class="project-header">
+                                                <h3><?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?></h3>
+                                                <?php if (!empty($property['property_location'])): ?>
+                                                    <h6><?= htmlspecialchars($property['property_location'], ENT_QUOTES, 'UTF-8') ?>
+                                                    </h6>
+                                                <?php endif; ?>
+                                            </div>
+                                            <?php foreach ($aboutProjectParagraphs as $paragraph): ?>
+                                                <p><?= htmlspecialchars($paragraph, ENT_QUOTES, 'UTF-8') ?></p>
+                                            <?php endforeach; ?>
+                                        </div>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Features -->
+                        <div id="hh-tab-features" class="tab-pane fade" role="tabpanel"
+                            aria-labelledby="hh-tab-features-btn">
+                            <!-- parent: .hh-amenities-01 -->
+                            <div class="hh-amenities-01 ">
+                                <div class="container-fluid">
+                                    <h3>Key Features & Amenities</h3>
+                                    <?php if ($amenitiesList): ?>
+                                        <ul class="amenities-list">
+                                            <?php foreach ($amenitiesList as $amenity): ?>
+                                                <?php $iconClass = $resolveAmenityIcon($amenity); ?>
+                                                <li>
+                                                    <i class="<?= htmlspecialchars($iconClass, ENT_QUOTES, 'UTF-8') ?>"
+                                                        aria-hidden="true"></i>
+                                                    <span><?= htmlspecialchars($amenity, ENT_QUOTES, 'UTF-8') ?></span>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php elseif ($featureItems): ?>
+                                        <ul class="amenities-list">
+                                            <?php foreach ($featureItems as $item): ?>
+                                                <?php $iconClass = $resolveAmenityIcon($item); ?>
+                                                <li>
+                                                    <i class="<?= htmlspecialchars($iconClass, ENT_QUOTES, 'UTF-8') ?>"
+                                                        aria-hidden="true"></i>
+                                                    <span><?= htmlspecialchars($item, ENT_QUOTES, 'UTF-8') ?></span>
+                                                </li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else: ?>
+                                        <p class="mb-0">Feature details will be available soon.</p>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Floor Plan -->
+                        <div id="hh-tab-floor" class="tab-pane fade" role="tabpanel" aria-labelledby="hh-tab-floor-btn">
+                            <div class="hh-floorplans-01 ">
+                                <div class="container-fluid">
+                                    <?php if ($floorPlans): ?>
+                                        <div class="row">
+                                            <div class="col-12 col-lg-7">
+                                                <div class="fp-canvas">
+                                                    <?php foreach ($floorPlans as $index => $plan): ?>
+                                                        <?php $paneId = 'fp-tab-' . $index; ?>
+                                                        <div class="fp-pane<?= $index === 0 ? ' active' : '' ?>"
+                                                            id="<?= htmlspecialchars($paneId, ENT_QUOTES, 'UTF-8') ?>">
+                                                            <?php if (!empty($plan['file'])): ?>
+                                                                <div class="fp-image">
+                                                                    <img src="<?= htmlspecialchars($plan['file'], ENT_QUOTES, 'UTF-8') ?>"
+                                                                        alt="<?= htmlspecialchars(($plan['title'] ?: 'Floor Plan') . ' layout', ENT_QUOTES, 'UTF-8') ?>"
+                                                                        data-fp-index="<?= $index ?>">
+                                                                    <button type="button" class="fp-view" aria-label="View image"
+                                                                        data-fp-index="<?= $index ?>">
+                                                                        <!-- <img src="assets/icons/plus.svg" alt="" aria-hidden="true"> -->
+                                                                        <svg width="18" height="18" viewBox="0 0 24 24">
+                                                                            <path d="M9 5H5v4H3V3h6v2zm6-2h6v6h-2V5h-4V3zM5 15H3v6h6v-2H5v-4zm16 0v6h-6v-2h4v-4h2z" fill="currentColor"></path>
+                                                                        </svg>
+                                                                    </button>
+                                                                </div>
+                                                            <?php else: ?>
+                                                                <div class="fp-placeholder">Floor plan preview not available.</div>
+                                                            <?php endif; ?>
+                                                        </div>
+                                                    <?php endforeach; ?>
+                                                </div>
+                                            </div>
+                                            <div class="col-12 col-lg-5">
+                                                <aside class="fp-aside">
+                                                    <?php foreach ($floorPlans as $index => $plan): ?>
+                                                        <?php $targetId = '#fp-tab-' . $index; ?>
+                                                        <button type="button" class="fp-box<?= $index === 0 ? ' active' : '' ?>"
+                                                            data-bs-toggle="tab"
+                                                            data-bs-target="<?= htmlspecialchars($targetId, ENT_QUOTES, 'UTF-8') ?>">
+                                                            <div class="fp-box-head">
+                                                                <img src="assets/icons/floorplan.png" alt="">
+                                                                <div>
+                                                                    <strong><?= htmlspecialchars($plan['title'] ?: ('Floor Plan ' . ($index + 1)), ENT_QUOTES, 'UTF-8') ?></strong>
+                                                                </div>
+                                                            </div>
+                                                            <ul class="fp-meta">
+                                                                <?php if (!empty($plan['area'])): ?>
+                                                                    <li><em>Total
+                                                                            Area</em><b><?= htmlspecialchars($plan['area'], ENT_QUOTES, 'UTF-8') ?></b>
+                                                                    </li>
+                                                                <?php endif; ?>
+                                                                <?php if (!empty($property['bedroom'])): ?>
+                                                                    <li><em>Bedrooms</em><b><?= htmlspecialchars($property['bedroom'], ENT_QUOTES, 'UTF-8') ?></b>
+                                                                    </li>
+                                                                <?php endif; ?>
+                                                                <?php if (!empty($plan['price'])): ?>
+                                                                    <li><em>Price</em><b><?= htmlspecialchars($plan['price'], ENT_QUOTES, 'UTF-8') ?></b>
+                                                                    </li>
+                                                                <?php endif; ?>
+                                                            </ul>
+                                                        </button>
+                                                    <?php endforeach; ?>
+                                                </aside>
+                                            </div>
+                                        </div>
+                                        <div class="fp-lightbox" aria-hidden="true">
+                                            <button type="button" class="fp-lightbox-close" aria-label="Close">×</button>
+                                            <button type="button" class="fp-lightbox-nav prev" aria-label="Previous"></button>
+                                            <img alt="Floor plan preview">
+                                            <button type="button" class="fp-lightbox-nav next" aria-label="Next"></button>
+                                        </div>
+                                    <?php else: ?>
+                                        <p class="mb-0">Floor plans will be shared soon.</p>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Developer -->
+                        <div id="hh-tab-developer" class="tab-pane fade" role="tabpanel"
+                            aria-labelledby="hh-tab-developer-btn">
+                            <div class="hh-developer-01">
+                                <div class="container-fluid">
+                                    <div class="row">
+                                        <div class="col-lg-12">
+                                            <h4>About the Developer</h4>
+                                        </div>
+                                        <div class="col-12">
+                                            <section class="dev-card " data-animation-in="animate__flipInX"
+                                                data-animation-out="animate__flipOutX">
+                                                <!-- <div class="dev-head">
+                                                    <div class="dev-ico">
+                                                        <img src="assets/flaticons/residential.png" width="25" alt="">
+                                                    </div>
+                                                    <div class="dev-title">
+                                                        <strong><?= htmlspecialchars($property['developer_name'] ?: 'Developer', ENT_QUOTES, 'UTF-8') ?></strong>
+                                                    </div>
+                                                </div> -->
+                                                <div class="dev-body">
+
+                                                    <div class="row justify-content-start align-items-center">
+                                                        <div class="col-lg-12">
+                                                            <?php if ($developerLogo): ?>
+                                                                <div class="developer-profile-logo">
+                                                                    <img class="img-fluid"
+                                                                        src="<?= htmlspecialchars($developerLogo, ENT_QUOTES, 'UTF-8') ?>"
+                                                                        alt="<?= htmlspecialchars($property['developer_name'] ?: 'Developer logo', ENT_QUOTES, 'UTF-8') ?>">
+                                                                </div>
+                                                            <?php endif; ?>
+                                                            <?php foreach ($aboutDeveloperParagraphs as $paragraph): ?>
+                                                                <p><?= htmlspecialchars($paragraph, ENT_QUOTES, 'UTF-8') ?>
+                                                                </p>
+                                                            <?php endforeach; ?>
+                                                        </div>
+                                                    </div>
+
+                                                    <?php if ($developerStats): ?>
+                                                        <div class="row dev-stats">
+                                                            <?php foreach ($developerStats as $stat): ?>
+                                                                <div class="col-6 col-lg-3">
+                                                                    <div class="stat">
+                                                                        <strong><?= htmlspecialchars($stat['value'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                                                        <span><?= htmlspecialchars($stat['label'], ENT_QUOTES, 'UTF-8') ?></span>
+                                                                    </div>
+                                                                </div>
+                                                            <?php endforeach; ?>
+                                                        </div>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </section>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+
+
+                <!-- Right: sidebar -->
+                <div class="col-12 col-lg-4">
+                    <aside>
+                        <!-- Contact Agent card -->
+                        <div class="agent-card " data-animation-in="animate__fadeIn"
+                            data-animation-out="animate__fadeOut">
+                            <!-- <div class="agent-title">Contact Agent</div> -->
+                            <div class="agent-head">
+                                <div class="avatar">
+                                    <img src="assets/icons/chat.png" alt="">
+                                </div>
+                                <div class="agent-info">
+                                    <strong>Contact Agent</strong>
+                                    <!-- <span>Schedule your private viewing</span> -->
+                                </div>
+                            </div>
+
+                            <form>
+                                <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
+                                <input type="hidden" name="property_title"
+                                    value="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                                <label>
+                                    <!-- <span class="field-head">
+                                        <img src="assets/icons/local-user.png" alt="" class="ico">
+                                        <span>Full Name *</span>
+                                    </span> -->
+                                    <input type="text" placeholder="Enter your full name">
+                                </label>
+
+                                <label>
+                                    <!-- <span class="field-head">
+                                        <img src="assets/flaticons/email.png" alt="" class="ico">
+                                        <span>Email Address *</span>
+                                    </span> -->
+                                    <input type="email" placeholder="your.email@example.com">
+                                </label>
+
+                                <label>
+                                    <!-- <span class="field-head">
+                                        <img src="assets/flaticons/phone.png" alt="" class="ico">
+                                        <span>Phone Number *</span>
+                                    </span> -->
+                                    <input type="tel" name="phone" id="phone" placeholder="+971 50 123 4567">
+                                </label>
+
+
+                                <label>
+                                    <!-- <span class="field-head">
+                                        <img src="assets/icons/conversation.png" alt="" class="ico">
+                                        <span>Inquiry Type</span>
+                                    </span> -->
+                                    <div class="select-ico ">
+                                        <select class="form-control select-dropDownClass">
+                                            <option>Select inquiry type</option>
+                                            <option>Schedule Viewing</option>
+                                            <option>Request Callback</option>
+                                            <option>Download Brochure</option>
+                                        </select>
+                                    </div>
+                                </label>
+
+                                <label>
+                                    <!-- <span class="field-head">
+                                        <img src="assets/icons/message.png" alt="" class="ico">
+                                        <span>Additional Message</span>
+                                    </span> -->
+                                    <textarea placeholder="Any specific questions or requirements…"></textarea>
+                                </label>
+
+                                <div class="g-recaptcha" data-sitekey="6LfsT9IrAAAAALx6HawW63nF2e1c9nLRJwXNDxTM"></div>
+
+                                <button type="button" class="send">Send Message</button>
+                                <p class="reg-note terms-and-privacy">
+                                    By clicking Submit, you agree to our
+                                    <a href="terms-and-conditions.php">Terms</a> &amp;
+                                    <a href="privacy-policy.php">Privacy Policy</a>.
+                                </p>
+                            </form>
+                        </div>
+                    </aside>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- parent: .hh-invest-01 -->
+    <div class="hh-invest-01 ">
+        <div class="container">
+            <div class="row">
+                <!-- LEFT: Highlights + Payment Plan -->
+                <div class="col-12 col-lg-8">
+
+                    <!-- Investment Highlights -->
+                    <section class="inv-high ">
+                        <header>
+                            <span><img src="assets/icons/growth-chart.png" alt="" width="25"></span>
+                            <h4>Investment Highlights</h4>
+                        </header>
+
+                        <?php if ($investmentHighlights): ?>
+                            <div class="hi-grid">
+                                <?php foreach ($investmentHighlights as $highlight): ?>
+                                    <div>
+                                        <strong><?= htmlspecialchars((string) $highlight['value'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                        <span><?= htmlspecialchars($highlight['label'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <?php if (!empty($highlight['note'])): ?>
+                                            <em><?= htmlspecialchars($highlight['note'], ENT_QUOTES, 'UTF-8') ?></em>
+                                        <?php endif; ?>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php else: ?>
+                            <p class="mb-0">Investment highlights will be shared soon.</p>
+                        <?php endif; ?>
+                    </section>
+
+                    <!-- Flexible Payment Plan -->
+                    <section class="pay-plan ">
+                        <header>
+                            <span><img src="assets/icons/wallet.png" alt="" width="25"></span>
+                            <h4>Flexible Payment Plan</h4>
+                        </header>
+
+                        <?php if ($paymentSchedule): ?>
+                            <div class="plan-list">
+                                <?php foreach ($paymentSchedule as $item): ?>
+                                    <?php
+                                    $percentageText = trim((string) ($item['percentage'] ?? ''));
+                                    $amountText = trim((string) ($item['amount'] ?? ''));
+                                    ?>
+                                    <div class="plan-item">
+                                        <?php if ($percentageText !== ''): ?>
+                                            <div class="pct"><?= htmlspecialchars($percentageText, ENT_QUOTES, 'UTF-8') ?></div>
+                                        <?php endif; ?>
+                                        <div class="txt">
+                                            <strong><?= htmlspecialchars($item['title'], ENT_QUOTES, 'UTF-8') ?></strong>
+                                        </div>
+                                        <div class="amt">
+                                            <?php if ($amountText !== ''): ?>
+                                                <b><?= htmlspecialchars($amountText, ENT_QUOTES, 'UTF-8') ?></b>
+                                            <?php endif; ?>
+                                            <?php if ($percentageText !== ''): ?>
+                                                <em><?= htmlspecialchars($percentageText, ENT_QUOTES, 'UTF-8') ?></em>
+                                            <?php endif; ?>
+                                        </div>
+                                    </div>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php else: ?>
+                            <p class="mb-0">Payment plan details will be updated shortly.</p>
+                        <?php endif; ?>
+                    </section>
+
+                </div>
+
+                <!-- RIGHT: Mortgage Calculator -->
+                <div class="col-12 col-lg-4 " data-animation-in="animate__fadeInRight"
+                    data-animation-out="animate__fadeOutRight">
+                    <aside class="mort-card " data-animation-in="animate__flipInY"
+                        data-animation-out="animate__flipOutY">
+                        <header>
+                            <!-- <img src="assets/icons/mortgage.png" alt="" width="20"> -->
+                            <h5>Mortgage Calculator</h5>
+                        </header>
+
+                        <!-- price + rate -->
+                        <div class="fld-row">
+                            <label>Property Price</label>
+                            <div class="amount">
+                                <span class="adorn">$</span>
+                                <input id="mc-price" type="text" value="2,500,000" inputmode="numeric" />
+                            </div>
+                        </div>
+
+                        <div class="fld-row">
+                            <label>Interest Rate (%)</label>
+                            <div class="amount">
+                                <span class="adorn">%</span>
+                                <input id="mc-rate" type="number" step="0.1" value="3.5" />
+                            </div>
+                        </div>
+
+                        <!-- Down payment -->
+                        <div class="range-row">
+                            <div class="r-label">
+                                <span>Down Payment : <b id="mc-dp-lbl">25%</b> (<b id="mc-dp-amt">AED 625,000</b>)</span>
+                            </div>
+                            <input id="mc-dp" type="range" min="10" max="50" step="1" value="25" />
+                            <div class="r-scale">
+                                <span>10%</span><span>50%</span>
+                            </div>
+                        </div>
+
+                        <!-- Loan term -->
+                        <div class="range-row">
+                            <div class="r-label">
+                                <span>Loan Term : <b id="mc-term-lbl">25 years</b></span>
+                            </div>
+                            <input id="mc-term" type="range" min="10" max="35" step="1" value="25" />
+                            <div class="r-scale">
+                                <span>10 years</span><span>35 years</span>
+                            </div>
+                        </div>
+
+                        <!-- Results -->
+                        <div class="result-row">
+                            <div class="pill gray">
+                                <span>Loan Amount</span>
+                                <strong id="mc-loan">AED 1,875,000</strong>
+                            </div>
+                            <div class="pill green">
+                                <span>Monthly Payment</span>
+                                <strong id="mc-monthly">AED 9,387</strong>
+                            </div>
+                        </div>
+
+                        <div class="totals">
+                            <div>
+                                <span>Total Interest</span>
+                                <b id="mc-interest">AED 941,008</b>
+                            </div>
+                            <div>
+                                <span>Total Payment</span>
+                                <b id="mc-total">AED 2,816,008</b>
+                            </div>
+                            <div>
+                                <span>P&I Payment</span>
+                                <b id="mc-pi">AED 9,387</b>
+                            </div>
+                        </div>
+
+                        <button type="button" class="cta">Get Pre-Approved</button>
+                    </aside>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- parent: .hh-location-01 -->
+    <div class="hh-location-01 ">
+        <div class="container">
+            <!-- Heading -->
+            <div class="row">
+                <div class="col-12">
+                    <div class="" data-animation-in="animate__fadeInDown" data-animation-out="animate__fadeOutUp">
+                        <div class="hh-location-01-head">
+                            <!-- <img src="assets/icons/location.png" alt="" /> -->
+                            <h3>Prime Location &amp; Connectivity</h3>
+                        </div>
+                        <?php if (!empty($property['property_location'])): ?>
+                            <p class="locationP">Located at
+                                <?= htmlspecialchars($property['property_location'], ENT_QUOTES, 'UTF-8') ?>.</p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Main grid -->
+            <div class="row">
+                <!-- LEFT: Map + Landmarks (col-lg-8) -->
+                <div class="col-12 col-lg-12 mb-5" data-animation-in="animate__fadeInLeft"
+                    data-animation-out="animate__fadeOutLeft">
+                    <div class="row">
+                        <!-- Map card -->
+                        <div class="col-12 col-md-6">
+                            <div class="hh-location-01-map " data-animation-in="animate__fadeIn"
+                                data-animation-out="animate__fadeOut">
+                                <?php if ($locationMap !== ''): ?>
+                                    <?php if (stripos($locationMap, '<iframe') !== false): ?>
+                                        <?= $locationMap ?>
+                                    <?php else: ?>
+                                        <iframe src="<?= htmlspecialchars($locationMap, ENT_QUOTES, 'UTF-8') ?>" width="100%"
+                                            height="375px" style="border:0;" allowfullscreen loading="lazy"
+                                            referrerpolicy="no-referrer-when-downgrade"></iframe>
+                                    <?php endif; ?>
+                                <?php else: ?>
+                                    <div class="map-placeholder">Location map coming soon.</div>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+
+                        <!-- Landmarks list -->
+                        <div class="col-12 col-md-6">
+                            <div class="hh-location-01-landmarks">
+                                <?php if ($locationAccess): ?>
+                                    <ul class="list-unstyled landmarks-list">
+                                        <?php foreach ($locationAccess as $item): ?>
+                                            <li class="d-flex align-items-center mb-2">
+                                                <div class="d-flex align-items-center">
+                                                    <img class="dot me-2" src="assets/icons/dot-green.png" alt="">
+                                                    <span class="fw-semibold">
+                                                        <?= htmlspecialchars($item['landmark'], ENT_QUOTES, 'UTF-8') ?>
+                                                    </span>
+                                                </div>
+                                                <div class="text-end">
+                                                    <?php if ($item['distance'] !== ''): ?>
+                                                        <span class="me-2"><?= htmlspecialchars($item['distance'], ENT_QUOTES, 'UTF-8') ?></span>
+                                                    <?php endif; ?>
+                                                    <?php if ($item['category'] !== ''): ?>
+                                                        <span class="text-white"><?= htmlspecialchars($item['category'], ENT_QUOTES, 'UTF-8') ?></span>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                <?php else: ?>
+                                    <p class="mb-0">Connectivity details will be available soon.</p>
+                                <?php endif; ?>
+                            </div>
+
+                            <div class="d-flex align-items-stretch">
+                                <!-- Permit card -->
+                                <div class="hh-location-01-permit " data-animation-in="animate__fadeIn"
+                                    data-animation-out="animate__fadeOut">
+                                    <div class="head">
+                                        <strong>Property Permit</strong>
+                                    </div>
+
+                                    <div class="qr-row">
+                                        <?php if ($permitBarcode): ?>
+                                            <img class="qr"
+                                                src="<?= htmlspecialchars($permitBarcode, ENT_QUOTES, 'UTF-8') ?>"
+                                                alt="Permit QR" />
+                                        <?php endif; ?>
+                                        <div class="permit-box h-100">
+                                            <span>Permit Number</span>
+                                            <b><?= htmlspecialchars($property['permit_no'] ?: 'Available on request', ENT_QUOTES, 'UTF-8') ?></b>
+                                            <?php if ($completionDate): ?>
+                                                <em>Completion :
+                                                    <?= htmlspecialchars($completionDate, ENT_QUOTES, 'UTF-8') ?></em>
+                                            <?php endif; ?>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- Quick contact -->
+                                <div class="hh-location-01-contact">
+                                    <div class="head">
+                                        <strong>Quick Contact</strong>
+                                    </div>
+
+                                    <button type="button" class="call"
+                                        onclick="window.location.href='tel:+971 42554683'">
+                                        <img src="assets/flaticons/phone.png" alt="" />
+                                        <span>Call Now: +971 42554683</span>
+                                    </button>
+
+                                    <button type="button" class="email" onclick="openPopup()">
+                                        <img src="assets/flaticons/email.png" alt="" />
+                                        <span>Email Agent</span>
+                                    </button>
+                                </div>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- parent: .hh-register-01 -->
+    <div class="hh-register-01 ">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-12">
+
+                    <form class="reg-card " action="#" method="post" novalidate>
+                        <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
+                        <input type="hidden" name="property_title"
+                            value="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                        <div class="reg-head">
+                            <h3>Register your interest</h3>
+                            <p>Fill form below and our agent will contact you shortly.</p>
+                        </div>
+
+                        <div class="row">
+
+                            <div class="col-12 col-lg-4">
+                                <!-- <label for="ri-name">Full Name*</label> -->
+                                <input id="ri-name" name="full_name" type="text" placeholder="Full Name*">
+                            </div>
+
+                            <div class="col-12 col-lg-4">
+                                <!-- <label for="ri-email">Email*</label> -->
+                                <input id="ri-email" name="email" type="email" placeholder="Email Address*">
+                            </div>
+
+                            <div class="col-12 col-lg-4">
+                                <!-- <label for="ri-mobile">Mobile*</label> -->
+                                <input id="ri-mobile" name="mobile" type="tel" placeholder="50 123 4567">
+                            </div>
+
+                            <div class="col-12 col-lg-4">
+                                <!-- <label for="ri-project">Interested In*</label> -->
+                                <select id="ri-project" name="project_name" class="select-dropDownClass">
+                                    <option value="">Interested In</option>
+                                    <option value="jumeirah-reside">Secondary</option>
+                                    <option value="downtown-dubai">Offplan</option>
+                                </select>
+                            </div>
+
+
+                            <div class="col-12 col-lg-4">
+                                <!-- <label for="ri-budget">Select Country*</label> -->
+                                <input id="ri-budget" name="budget_range" type="text" placeholder="Budget Range*">
+                            </div>
+
+                            <div class="col-12 col-lg-4">
+                                <!-- <label class="only-for-space">&nbsp;</label> -->
+                                <button type="submit" class="submit-btn">Submit Details</button>
+                            </div>
+                        </div>
+
+                        <p class="reg-note">
+                            By clicking Submit, you agree to our
+                            <a href="terms-and-conditions.php">Terms</a> &amp;
+                            <a href="privacy-policy.php">Privacy Policy</a>.
+                        </p>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- parent: .hh-cta-01 -->
+    <div class="hh-cta-01 ">
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+
+                    <div class="cta-banner " data-animation-in="animate__flipInX"
+                        data-animation-out="animate__flipOutX">
+                        <h3>Ready to Invest in Your Future?</h3>
+                        <p>Contact our property specialists today for exclusive pricing.</p>
+
+                        <div class="cta-actions">
+                            <button onclick="window.location.href='tel:+971 42554683'" type="button"
+                                class="cta-btn">Call Now</button>
+                            <button type="button" class="cta-btn" onclick="openPopup()">Enquire Now</button>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    <!-- footer five start -->
+    <div class="footer-section-five">
+        <div class="container">
+            <div class="row gutter-y-30">
+                <div class="col-12 col-lg-3 col-md-6">
+                    <div class="footer-about-five">
+                        <div class="footer-logo-five animate fadeInUp wow">
+                            <img src="assets/images/logo/logo.svg">
+                        </div>
+                        <p class="lead">Your trusted partner in premium real estate across the UAE and Middle East. We
+                            bring
+                            you curated properties, expert advice and a smooth real estate experience tailored for
+                            modern
+                            living.
+                        </p>
+                        <ul class="footer-social-media-five">
+                            <li>
+                                <a href="https://www.instagram.com/houzzhunt/?hl=en"><img
+                                        src="assets/icons/instagram.png" alt="icon"></a>
+                            </li>
+                            <li>
+                                <a href="https://www.facebook.com/people/Houzz-Hunt/61574436629351/"><img
+                                        src="assets/icons/facebook.png" alt="icon"></a>
+                            </li>
+                            <li>
+                                <a href="https://x.com/HouzzHunt"><img src="assets/icons/twitter.png" alt="icon"></a>
+                            </li>
+                            <li>
+                                <a href="https://www.linkedin.com/company/houzz-hunt/"><img
+                                        src="assets/icons/linkedin.png" alt="icon"></a>
+                            </li>
+                            <li>
+                                <a href="https://www.youtube.com/@HouzzHunt"><img src="assets/icons/youtube.png"
+                                        alt="icon"></a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-6 col-lg-3 col-md-6">
+                    <div class="footer-widget-two">
+                        <h4>Usefull Links</h4>
+                        <ul class="footer-menu-two">
+                            <li>
+
+                                <a href="index.php">Home</a>
+                            </li>
+                            <li>
+
+                                <a href="about.php">About</a>
+                            </li>
+                            <li>
+
+                                <a href="services.php">Services </a>
+                            </li>
+                            <li>
+
+                                <a href="blogs.php">Blogs</a>
+                            </li>
+                            <li>
+
+                                <a href="contact.php">Contact Us</a>
+                            </li>
+                            <li>
+
+                                <a href="careers.php">Career</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-6 col-lg-3 col-md-6">
+                    <div class="footer-widget-two">
+                        <h4>Services</h4>
+                        <ul class="footer-menu-two">
+                            <li>
+
+                                <a href="residential.php">Residential</a>
+                            </li>
+                            <li>
+
+                                <a href="commercial.php">Commercial</a>
+                            </li>
+                            <li>
+
+                                <a href="mortgage-services.php">Mortgage Services</a>
+                            </li>
+                            <li>
+
+                                <a href="investment.php">Investment</a>
+                            </li>
+                            <li>
+
+                                <a href="valuation-advisory.php">Valuation & Advisory</a>
+                            </li>
+                            <li>
+
+                                <a href="research.php">Research</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-3 col-md-6">
+                    <div class="footer-widget-contact">
+                        <h4>Contact Us</h4>
+                        <ul class="footer-location-four">
+                            <li>
+                                <span><img src="assets/images/svg/footer-two/footer-two-mail.svg" alt="icon"></span>
+                                <a href="mailto:contact@houzzhunt.com">contact@houzzhunt.com</a>
+                            </li>
+                            <li>
+                                <span><img src="assets/images/svg/footer-two/footer-two-address.svg" alt="icon"></span>
+                                <p>806, Capital Golden Tower
+
+                                    Business Bay, Dubai, U.A.E</p>
+                            </li>
+                            <li>
+                                <span><img src="assets/images/svg/footer-two/footer-two-call.svg" alt="icon"></span>
+                                <a href="telto:+97142554683">+971 42554683</a>
+                            </li>
+                        </ul>
+
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+    <!-- footer five end -->
+
+    <!-- Popup Form -->
+    <div class="popup-overlay" id="propertyEnquirey">
+        <div class="popup-content">
+            <div class="popup-image"></div>
+            <div class="popup-form">
+                <div class="popup-close" onclick="closePopup()">X</div>
+                <h4 class="heading-title"><span>Register Your Interest</span></h4>
+                <p style="font-size: 14px !important; margin-bottom: 10px;">
+                    Unlock expert advice, exclusive listings & investment insights.
+                </p>
+                <form method="POST" class="appointment-form" action="danuber">
+                    <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
+                    <input type="hidden" name="property_title"
+                        value="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                    <div class="form-group">
+                        <label for="full_name">Enter Name</label>
+                        <input type="text" name="name" id="full_name" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="email_address">Enter Email</label>
+                        <input type="email" name="email" id="email_address" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="country">Select Country</label>
+                        <input type="text" name="country" id="country" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="mobile_number">Phone Number</label>
+                        <input type="tel" name="phone" id="mobile_number" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="g-recaptcha" data-sitekey="6LfsT9IrAAAAALx6HawW63nF2e1c9nLRJwXNDxTM"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <button type="submit" class="gradient-btn btn-green-glossy w-100 mt-3 text-center">
+                            Submit Enquiry
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+
+    <!-- Download Brochure -->
+    <div class="popup-overlay" id="downloadBrochure">
+        <div class="popup-content">
+            <div class="popup-image"></div>
+            <div class="popup-form">
+                <div class="popup-close" onclick="closeBrochurepopup()">X</div>
+                <h4 class="heading-title"><span>Download Brochure</span></h4>
+                <p style="font-size: 14px !important; margin-bottom: 10px;">
+                    Get your brochure instantly. Enter your details below to access the download.
+                </p>
+                <form method="POST" class="appointment-form" action="download-brochure">
+                    <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
+                    <input type="hidden" name="property_title"
+                        value="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                    <input type="hidden" name="brochure_url"
+                        value="<?= htmlspecialchars($brochure, ENT_QUOTES, 'UTF-8') ?>">
+                    <div class="form-group">
+                        <label for="brochure_name">Full Name</label>
+                        <input type="text" name="brochure_name" id="brochure_name" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="brochure_email">Email Address</label>
+                        <input type="email" name="brochure_email" id="brochure_email" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="brochure_country">Country</label>
+                        <input type="text" name="brochure_country" id="brochure_country" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="brochure_phone">Phone Number</label>
+                        <input type="tel" name="brochure_phone" id="brochure_phone" class="form-control" required>
+                    </div>
+
+                    <div class="form-group">
+                        <div class="g-recaptcha" data-sitekey="6LfsT9IrAAAAALx6HawW63nF2e1c9nLRJwXNDxTM"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <button type="submit" class="gradient-btn btn-green-glossy w-100 mt-3 text-center">
+                            Download Brochure
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+
+    <script src="assets/vendors/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/vendors/jquery/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/country-select-js@2.0.1/build/js/countrySelect.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/18.2.1/js/intlTelInput.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+    <!-- reCAPTCHA script -->
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const animatedElements = Array.from(document.querySelectorAll('.[data-animation-in]'));
+
+            if (!animatedElements.length) {
+                return;
+            }
+
+            const ensureBaseClasses = (el) => {
+                if (!el.classList.contains('animate__animated')) {
+                    el.classList.add('animate__animated');
+                }
+            };
+
+            const handleAnimationEnd = (event) => {
+                const el = event.currentTarget;
+                if (event.target !== el) {
+                    return;
+                }
+
+                const inClass = el.dataset.animationIn;
+                const outClass = el.dataset.animationOut;
+
+                if (inClass && el.classList.contains(inClass)) {
+                    el.classList.remove(inClass);
+                }
+
+                if (outClass && el.classList.contains(outClass)) {
+                    el.classList.remove(outClass);
+                    el.classList.remove('animate-scroll-visible');
+                }
+            };
+
+            animatedElements.forEach((el) => {
+                el.addEventListener('animationend', handleAnimationEnd);
+            });
+
+            if (!('IntersectionObserver' in window)) {
+                animatedElements.forEach((el) => {
+                    ensureBaseClasses(el);
+                    el.classList.add('animate-scroll-visible');
+                    const inClass = el.dataset.animationIn;
+                    if (inClass) {
+                        el.classList.add(inClass);
+                    }
+                });
+                return;
+            }
+
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    const el = entry.target;
+                    const inClass = el.dataset.animationIn;
+                    const outClass = el.dataset.animationOut;
+
+                    ensureBaseClasses(el);
+
+                    if (entry.isIntersecting) {
+                        el.classList.add('animate-scroll-visible');
+                        if (outClass) {
+                            el.classList.remove(outClass);
+                        }
+                        if (inClass) {
+                            el.classList.remove(inClass);
+                            // Force reflow to restart the animation
+                            void el.offsetWidth;
+                            el.classList.add(inClass);
+                        }
+                    } else {
+                        if (outClass) {
+                            if (inClass) {
+                                el.classList.remove(inClass);
+                            }
+                            el.classList.add(outClass);
+                        } else {
+                            el.classList.remove('animate-scroll-visible');
+                            if (inClass) {
+                                el.classList.remove(inClass);
+                            }
+                        }
+                    }
+                });
+            }, {
+                threshold: 0.2,
+                rootMargin: '0px 0px -10% 0px'
+            });
+
+            animatedElements.forEach((el) => observer.observe(el));
+        });
+    </script>
+
+
+    <script>
+        /* ---- Swiper thumbs + main ---- */
+        (function() {
+            // thumbs
+            const thumbs = new Swiper('.hh-gallery-01 .hh-gallery-01-thumbs', {
+                slidesPerView: 4.5,
+                spaceBetween: 12,
+                watchSlidesProgress: true,
+                breakpoints: {
+                    576: {
+                        slidesPerView: 5,
+                        spaceBetween: 12
+                    },
+                    992: {
+                        slidesPerView: 5,
+                        spaceBetween: 14
+                    }
+                }
+            });
+
+            // main
+            const main = new Swiper('.hh-gallery-01 .hh-gallery-01-main', {
+                slidesPerView: 1,
+                speed: 500,
+                effect: 'slide',
+                thumbs: {
+                    swiper: thumbs
+                },
+                on: {
+                    slideChange: function() {
+                        // update fraction + progress
+                        const cur = this.realIndex + 1;
+                        const total = this.slides.length;
+                        const root = this.el.closest('.hh-gallery-01');
+                        root.querySelector('.fraction span:first-child').textContent = cur;
+                        root.querySelector('.fraction span:last-child').textContent = total;
+                        root.querySelector('.progress i').style.width = (cur / total * 100) + '%';
+                    }
+                }
+            });
+
+            // init fraction at load
+            main.emit('slideChange');
+
+            // custom nav
+            const prevBtn = document.querySelector('.hh-gallery-01 .nav.prev');
+            if (prevBtn) {
+                prevBtn.addEventListener('click', () => main.slidePrev());
+            }
+            const nextBtn = document.querySelector('.hh-gallery-01 .nav.next');
+            if (nextBtn) {
+                nextBtn.addEventListener('click', () => main.slideNext());
+            }
+
+            // Lightbox
+            const lb = document.querySelector('.hh-gallery-01 .hh-gallery-01-lightbox');
+            const lbImg = lb.querySelector('img');
+            let lbIndex = 0;
+
+            function openLB(i) {
+                lbIndex = i;
+                lbImg.src = main.slides[lbIndex].querySelector('img').src;
+                lb.classList.add('open');
+                lb.setAttribute('aria-hidden', 'false');
+            }
+
+            function closeLB() {
+                lb.classList.remove('open');
+                lb.setAttribute('aria-hidden', 'true');
+            }
+
+            function prevLB() {
+                lbIndex = (lbIndex - 1 + main.slides.length) % main.slides.length;
+                lbImg.src = main.slides[lbIndex].querySelector('img').src;
+                main.slideTo(lbIndex);
+            }
+
+            function nextLB() {
+                lbIndex = (lbIndex + 1) % main.slides.length;
+                lbImg.src = main.slides[lbIndex].querySelector('img').src;
+                main.slideTo(lbIndex);
+            }
+
+            // click on main image or "View All"
+            document.querySelectorAll('.hh-gallery-01 .hh-gallery-01-main .swiper-slide img').forEach((img, i) => {
+                img.style.cursor = 'zoom-in';
+                img.addEventListener('click', () => openLB(i));
+            });
+            const viewAllBtn = document.querySelector('.hh-gallery-01 [data-action="view-all"]');
+            if (viewAllBtn) {
+                viewAllBtn.addEventListener('click', () => openLB(main.realIndex));
+            }
+            const fullscreenBtn = document.querySelector('.hh-gallery-01 .fullscreen');
+            if (fullscreenBtn) {
+                fullscreenBtn.addEventListener('click', () => openLB(main.realIndex));
+            }
+            const videoBtn = document.querySelector('.hh-gallery-01 [data-action="video"]');
+            if (videoBtn && videoBtn.dataset.video) {
+                videoBtn.addEventListener('click', () => {
+                    window.open(videoBtn.dataset.video, '_blank');
+                });
+            }
+
+            // lb controls
+            lb.querySelector('.lb-close').addEventListener('click', closeLB);
+            lb.querySelector('.lb-prev').addEventListener('click', prevLB);
+            lb.querySelector('.lb-next').addEventListener('click', nextLB);
+            lb.addEventListener('click', (e) => {
+                if (e.target === lb) closeLB();
+            });
+
+            // keyboard nav
+            window.addEventListener('keydown', (e) => {
+                if (!lb.classList.contains('open')) return;
+                if (e.key === 'Escape') closeLB();
+                if (e.key === 'ArrowLeft') prevLB();
+                if (e.key === 'ArrowRight') nextLB();
+            });
+        })();
+    </script>
+
+    <script>
+        (function() {
+            const section = document.querySelector('.hh-floorplans-01');
+            if (!section) return;
+            const canvas = section.querySelector('.fp-canvas');
+            const buttons = Array.from(section.querySelectorAll('.fp-aside [data-bs-toggle="tab"]'));
+            if (!canvas || buttons.length === 0) {
+                return;
+            }
+
+            function showPane(targetSel) {
+                canvas.querySelectorAll('.fp-pane').forEach(p => p.classList.remove('active'));
+                const pane = canvas.querySelector(targetSel);
+                if (pane) pane.classList.add('active');
+            }
+
+            function activateButton(index) {
+                buttons.forEach(b => {
+                    b.classList.remove('active');
+                    b.setAttribute('aria-selected', 'false');
+                });
+                const btn = buttons[index];
+                if (!btn) {
+                    return;
+                }
+                btn.classList.add('active');
+                btn.setAttribute('aria-selected', 'true');
+                const targetSel = btn.getAttribute('data-bs-target');
+                if (targetSel) {
+                    showPane(targetSel);
+                }
+            }
+
+            activateButton(0);
+
+            buttons.forEach((btn, index) => {
+                btn.addEventListener('click', function() {
+                    activateButton(index);
+                });
+            });
+
+            const lightbox = section.querySelector('.fp-lightbox');
+            const lbImg = lightbox ? lightbox.querySelector('img') : null;
+            const viewButtons = Array.from(section.querySelectorAll('.fp-view'));
+            const planImages = Array.from(section.querySelectorAll('.fp-pane img[data-fp-index]'))
+                .map(img => {
+                    const planIndex = Number(img.getAttribute('data-fp-index'));
+                    if (Number.isNaN(planIndex)) {
+                        return null;
+                    }
+                    return {
+                        index: planIndex,
+                        el: img
+                    };
+                })
+                .filter(Boolean)
+                .sort((a, b) => a.index - b.index);
+            let lbIndex = 0;
+
+            function syncActive(index) {
+                activateButton(index);
+            }
+
+            function setLightboxImage(position) {
+                const item = planImages[position];
+                if (!lbImg || !item) {
+                    return;
+                }
+                const img = item.el;
+                lbImg.src = img.src;
+                lbImg.alt = img.alt || 'Floor plan preview';
+                lbIndex = position;
+                syncActive(item.index);
+            }
+
+            function openLightbox(index) {
+                if (!lightbox || !lbImg) {
+                    return;
+                }
+                const position = planImages.findIndex(item => item.index === index);
+                if (position === -1) {
+                    return;
+                }
+                lightbox.classList.add('open');
+                lightbox.setAttribute('aria-hidden', 'false');
+                setLightboxImage(position);
+            }
+
+            function closeLightbox() {
+                if (!lightbox) {
+                    return;
+                }
+                lightbox.classList.remove('open');
+                lightbox.setAttribute('aria-hidden', 'true');
+            }
+
+            function prevLightbox() {
+                if (!planImages.length) return;
+                const position = (lbIndex - 1 + planImages.length) % planImages.length;
+                setLightboxImage(position);
+            }
+
+            function nextLightbox() {
+                if (!planImages.length) return;
+                const position = (lbIndex + 1) % planImages.length;
+                setLightboxImage(position);
+            }
+
+            if (lightbox && planImages.length <= 1) {
+                lightbox.classList.add('single');
+            }
+
+            viewButtons.forEach(btn => {
+                btn.addEventListener('click', (event) => {
+                    const index = Number(btn.getAttribute('data-fp-index'));
+                    if (!Number.isNaN(index)) {
+                        event.stopPropagation();
+                        openLightbox(index);
+                    }
+                });
+            });
+
+            planImages.forEach(item => {
+                const img = item.el;
+                img.style.cursor = 'zoom-in';
+                img.addEventListener('click', () => {
+                    openLightbox(item.index);
+                });
+            });
+
+            if (lightbox) {
+                const closeBtn = lightbox.querySelector('.fp-lightbox-close');
+                const prevBtn = lightbox.querySelector('.fp-lightbox-nav.prev');
+                const nextBtn = lightbox.querySelector('.fp-lightbox-nav.next');
+
+                if (closeBtn) {
+                    closeBtn.addEventListener('click', closeLightbox);
+                }
+                if (prevBtn) {
+                    prevBtn.addEventListener('click', prevLightbox);
+                }
+                if (nextBtn) {
+                    nextBtn.addEventListener('click', nextLightbox);
+                }
+
+                lightbox.addEventListener('click', (event) => {
+                    if (event.target === lightbox) {
+                        closeLightbox();
+                    }
+                });
+
+                window.addEventListener('keydown', (event) => {
+                    if (!lightbox.classList.contains('open')) {
+                        return;
+                    }
+                    if (event.key === 'Escape') {
+                        closeLightbox();
+                    } else if (event.key === 'ArrowLeft') {
+                        prevLightbox();
+                    } else if (event.key === 'ArrowRight') {
+                        nextLightbox();
+                    }
+                });
+            }
+        })();
+    </script>
+
+    <script>
+        (function() {
+            const root = document.querySelector('.hh-invest-01');
+            if (!root) return;
+
+            const priceEl = root.querySelector('#mc-price');
+            const rateEl = root.querySelector('#mc-rate');
+            const dpEl = root.querySelector('#mc-dp');
+            const termEl = root.querySelector('#mc-term');
+
+            const dpLbl = root.querySelector('#mc-dp-lbl');
+            const dpAmt = root.querySelector('#mc-dp-amt');
+            const termLbl = root.querySelector('#mc-term-lbl');
+
+            const outLoan = root.querySelector('#mc-loan');
+            const outMon = root.querySelector('#mc-monthly');
+            const outInt = root.querySelector('#mc-interest');
+            const outTot = root.querySelector('#mc-total');
+            const outPI = root.querySelector('#mc-pi');
+
+            function toNum(str) {
+                return Number(String(str).replace(/[^\d.]/g, ''));
+            }
+
+            function fmt(n) {
+                const parts = Math.round(n).toString().split('');
+                for (let i = parts.length - 3; i > 0; i -= 3) {
+                    parts.splice(i, 0, ',');
+                }
+                return 'AED ' + parts.join('');
+            }
+
+            function compute() {
+                const P = toNum(priceEl.value || 0);
+                const rA = Number(rateEl.value || 0); // annual %
+                const dp = Number(dpEl.value || 0); // %
+                const yrs = Number(termEl.value || 0);
+
+                const down = P * dp / 100;
+                const L = Math.max(P - down, 0);
+                const i = (rA / 100) / 12;
+                const n = yrs * 12;
+
+                const M = (i > 0) ? (L * i * Math.pow(1 + i, n)) / (Math.pow(1 + i, n) - 1) : (n > 0 ? L / n : 0);
+                const totalPay = M * n;
+                const totalInt = totalPay - L;
+
+                dpLbl.textContent = dp + '%';
+                dpAmt.textContent = fmt(down);
+                termLbl.textContent = yrs + ' years';
+
+                outLoan.textContent = fmt(L);
+                outMon.textContent = fmt(M);
+                outPI.textContent = fmt(M);
+                outTot.textContent = fmt(totalPay);
+                outInt.textContent = fmt(totalInt);
+            }
+
+            // formatting on blur for price
+            priceEl.addEventListener('blur', () => {
+                priceEl.value = (toNum(priceEl.value) || 0).toLocaleString();
+                compute();
+            });
+            [priceEl, rateEl].forEach(el => el.addEventListener('input', compute));
+            [dpEl, termEl].forEach(el => el.addEventListener('input', compute));
+
+            // init
+            priceEl.value = (toNum(priceEl.value) || 0).toLocaleString();
+            compute();
+        })();
+    </script>
+
+    <script>
+        function openPopup() {
+            document.getElementById("propertyEnquirey").classList.add("show");
+            document.body.classList.add("no-scroll");
+        }
+
+        function closePopup() {
+            document.getElementById("propertyEnquirey").classList.remove("show");
+            document.body.classList.remove("no-scroll");
+        }
+
+        function Brochurepopup() {
+            document.getElementById("downloadBrochure").classList.add("show");
+            document.body.classList.add("no-scroll");
+        }
+
+        function closeBrochurepopup() {
+            document.getElementById("downloadBrochure").classList.remove("show");
+            document.body.classList.remove("no-scroll");
+        }
+
+        // Optional: Auto open after delay
+        // window.addEventListener("load", function () {
+        //   setTimeout(function () {
+        //     openPopup();
+        //   }, 3000);
+        // });
+    </script>
+
+    <script>
+        $(document).ready(function() {
+            $("#country").countrySelect({
+                defaultCountry: "ae",
+                preferredCountries: ['ae', 'in', 'gb'] // gb = United Kingdom
+            });
+
+            $("#brochure_country").countrySelect({
+                defaultCountry: "ae",
+                preferredCountries: ['ae', 'in', 'gb']
+            });
+
+            $("#ri-budget").countrySelect({
+                defaultCountry: "ae",
+                preferredCountries: ['ae', 'in', 'gb']
+            });
+        });
+    </script>
+
+
+    <script>
+        // Initialize multiple inputs with intlTelInput
+        function initIntlTelInput(id) {
+            const input = document.querySelector(id);
+            if (!input) return null;
+
+            const iti = window.intlTelInput(input, {
+                initialCountry: "ae", // Default UAE
+                separateDialCode: true,
+                preferredCountries: ["ae", "in", "us", "gb", "sa"], // Common options
+            });
+
+            // Get full number on form submit
+            input.form.addEventListener("submit", function() {
+                input.value = iti.getNumber();
+            });
+
+            return iti;
+        }
+
+        // Apply on both IDs
+        const itiPhone = initIntlTelInput("#phone");
+        const itiRiMobile = initIntlTelInput("#ri-mobile");
+    </script>
+
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.select-dropDownClass').forEach(el => {
+                new Choices(el, {
+                    searchEnabled: false,
+                    itemSelectText: '',
+                    shouldSort: false
+                });
+            });
+        });
+    </script>
+
+</body>
+
+</html>

--- a/buy-properties.php
+++ b/buy-properties.php
@@ -1,11 +1,507 @@
 <?php
 
-$title = 'Luxury Property for Sale in Dubai | Villas & Apartments';
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/config.php';
+
+$itemsPerPage = 6;
+$currentPage = (int)filter_input(
+    INPUT_GET,
+    'page',
+    FILTER_VALIDATE_INT,
+    [
+        'options' => [
+            'default' => 1,
+            'min_range' => 1,
+        ],
+    ]
+);
+
+$sanitizeNumericString = static function ($value): string {
+    if (!is_string($value)) {
+        return '';
+    }
+
+    $value = trim($value);
+
+    return $value !== '' && ctype_digit($value) ? $value : '';
+};
+
+$allowedSortOptions = [
+    'price_desc',
+    'price_asc',
+    'name_asc',
+    'newest',
+    'oldest',
+    'completion_date',
+];
+
+$filters = [
+    'q' => trim((string)(filter_input(INPUT_GET, 'q', FILTER_UNSAFE_RAW) ?? '')),
+    'project_name' => trim((string)(filter_input(INPUT_GET, 'project_name', FILTER_UNSAFE_RAW) ?? '')),
+    'location' => trim((string)(filter_input(INPUT_GET, 'location', FILTER_UNSAFE_RAW) ?? '')),
+    'property_type' => trim((string)(filter_input(INPUT_GET, 'property_type', FILTER_UNSAFE_RAW) ?? '')),
+    'bedrooms' => trim((string)(filter_input(INPUT_GET, 'bedrooms', FILTER_UNSAFE_RAW) ?? '')),
+    'location_query' => trim((string)(filter_input(INPUT_GET, 'location_query', FILTER_UNSAFE_RAW) ?? '')),
+    'completion_year' => filter_input(INPUT_GET, 'completion_year', FILTER_VALIDATE_INT) ?: '',
+    'min_price' => $sanitizeNumericString(filter_input(INPUT_GET, 'min_price', FILTER_UNSAFE_RAW)),
+    'max_price' => $sanitizeNumericString(filter_input(INPUT_GET, 'max_price', FILTER_UNSAFE_RAW)),
+    'sort' => trim((string)(filter_input(INPUT_GET, 'sort', FILTER_UNSAFE_RAW) ?? '')),
+];
+
+if ($filters['sort'] !== '' && !in_array($filters['sort'], $allowedSortOptions, true)) {
+    $filters['sort'] = '';
+}
+
+$minPriceValue = $filters['min_price'] !== '' ? (float)$filters['min_price'] : null;
+$maxPriceValue = $filters['max_price'] !== '' ? (float)$filters['max_price'] : null;
+$effectiveMinPrice = $minPriceValue;
+$effectiveMaxPrice = $maxPriceValue;
+if ($effectiveMinPrice !== null && $effectiveMaxPrice !== null && $effectiveMinPrice > $effectiveMaxPrice) {
+    $temp = $effectiveMinPrice;
+    $effectiveMinPrice = $effectiveMaxPrice;
+    $effectiveMaxPrice = $temp;
+}
+
+$parsePriceToNumber = static function ($price) {
+    if (!is_string($price)) {
+        return null;
+    }
+
+    $normalized = strtoupper($price);
+    $normalized = str_replace(['AED', 'DHS'], '', $normalized);
+    $normalized = str_replace([',', ' '], '', $normalized);
+    $normalized = preg_replace('/[^0-9MK\.]/', '', $normalized);
+
+    if (!is_string($normalized)) {
+        return null;
+    }
+
+    if ($normalized === '') {
+        return null;
+    }
+
+    $multiplier = 1;
+    if (str_ends_with($normalized, 'M')) {
+        $multiplier = 1000000;
+        $normalized = substr($normalized, 0, -1);
+    } elseif (str_ends_with($normalized, 'K')) {
+        $multiplier = 1000;
+        $normalized = substr($normalized, 0, -1);
+    }
+
+    if ($normalized === '' || !is_numeric($normalized)) {
+        return null;
+    }
+
+    return (float)$normalized * $multiplier;
+};
+
+$filterOptions = [
+    'locations' => [],
+    'property_types' => [],
+    'bedrooms' => [],
+    'completion_years' => [],
+];
+
+$bedroomOptionMap = [];
+$buyProperties = [];
+$propertyCount = 0;
+$totalPages = 1;
+$offset = 0;
+
+try {
+    $pdo = hh_db();
+
+    $filterOptions['locations'] = array_values(array_filter(array_map(
+        static fn($value) => is_string($value) ? trim($value) : '',
+        $pdo->query('SELECT DISTINCT property_location FROM buy_properties_list WHERE property_location IS NOT NULL AND TRIM(property_location) <> "" ORDER BY property_location ASC')->fetchAll(\PDO::FETCH_COLUMN)
+    )));
+
+    $filterOptions['property_types'] = array_values(array_filter(array_map(
+        static fn($value) => is_string($value) ? trim($value) : '',
+        $pdo->query('SELECT DISTINCT property_type FROM buy_properties_list WHERE property_type IS NOT NULL AND TRIM(property_type) <> "" ORDER BY property_type ASC')->fetchAll(\PDO::FETCH_COLUMN)
+    )));
+
+    $rawBedrooms = $pdo->query('SELECT DISTINCT bedroom FROM buy_properties_list WHERE bedroom IS NOT NULL AND TRIM(bedroom) <> ""')->fetchAll(\PDO::FETCH_COLUMN);
+    if ($rawBedrooms) {
+        foreach ($rawBedrooms as $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+
+            $value = trim($value);
+            if ($value === '') {
+                continue;
+            }
+
+            $label = $value;
+            $lower = strtolower($value);
+            if ($lower === 'studio') {
+                $label = 'Studio';
+            } elseif (is_numeric($value)) {
+                $label = (int)$value === 1 ? '1 Bed' : $value . ' Beds';
+            }
+
+            $bedroomOptionMap[$value] = $label;
+        }
+
+        ksort($bedroomOptionMap, SORT_NATURAL);
+        $filterOptions['bedrooms'] = $bedroomOptionMap;
+    }
+
+    $filterOptions['completion_years'] = array_values(array_filter(array_map(
+        static fn($value) => $value !== null ? (int)$value : null,
+        $pdo->query('SELECT DISTINCT YEAR(completion_date) AS completion_year FROM buy_properties_list WHERE completion_date IS NOT NULL AND completion_date <> "0000-00-00" ORDER BY completion_year ASC')->fetchAll(\PDO::FETCH_COLUMN)
+    ), static fn($value) => $value !== null && $value > 0));
+
+    $filterClauses = [];
+    $queryParams = [];
+
+    if ($filters['q'] !== '') {
+        $filterClauses[] = '(project_name LIKE :search OR property_title LIKE :search)';
+        $queryParams[':search'] = '%' . $filters['q'] . '%';
+    }
+
+    if ($filters['project_name'] !== '') {
+        $filterClauses[] = 'project_name LIKE :project_name_filter';
+        $queryParams[':project_name_filter'] = '%' . $filters['project_name'] . '%';
+    }
+
+    if ($filters['location'] !== '') {
+        $filterClauses[] = 'property_location = :location';
+        $queryParams[':location'] = $filters['location'];
+    }
+
+    if ($filters['property_type'] !== '') {
+        $filterClauses[] = 'property_type = :property_type';
+        $queryParams[':property_type'] = $filters['property_type'];
+    }
+
+    if ($filters['bedrooms'] !== '') {
+        $filterClauses[] = 'bedroom = :bedrooms';
+        $queryParams[':bedrooms'] = $filters['bedrooms'];
+    }
+
+    if ($filters['location_query'] !== '') {
+        $filterClauses[] = 'property_location LIKE :location_query';
+        $queryParams[':location_query'] = '%' . $filters['location_query'] . '%';
+    }
+
+    if ($filters['completion_year'] !== '') {
+        $filterClauses[] = 'completion_date IS NOT NULL AND completion_date <> "0000-00-00" AND YEAR(completion_date) = :completion_year';
+        $queryParams[':completion_year'] = (int)$filters['completion_year'];
+    }
+
+    $whereClause = $filterClauses ? ' WHERE ' . implode(' AND ', $filterClauses) : '';
+
+    $stmt = $pdo->prepare(
+        'SELECT id, hero_banner, gallery_images, project_status, property_type, project_name, property_title, property_location, starting_price, bedroom, bathroom, total_area, completion_date, created_at
+            FROM buy_properties_list'
+        . $whereClause .
+        ' ORDER BY created_at DESC'
+    );
+
+    foreach ($queryParams as $param => $value) {
+        $stmt->bindValue($param, $value);
+    }
+
+    $stmt->execute();
+    $allProperties = $stmt->fetchAll();
+
+    $filteredProperties = [];
+    foreach ($allProperties as $property) {
+        $priceNumeric = $parsePriceToNumber($property['starting_price'] ?? null);
+
+        if ($effectiveMinPrice !== null && ($priceNumeric === null || $priceNumeric < $effectiveMinPrice)) {
+            continue;
+        }
+
+        if ($effectiveMaxPrice !== null && ($priceNumeric === null || $priceNumeric > $effectiveMaxPrice)) {
+            continue;
+        }
+
+        $filteredProperties[] = $property;
+    }
+
+    $filteredProperties = array_values($filteredProperties);
+
+    $sortOption = $filters['sort'] ?: 'newest';
+
+    $getComparableName = static function (array $property): string {
+        $name = '';
+        if (isset($property['project_name']) && is_string($property['project_name'])) {
+            $name = trim($property['project_name']);
+        }
+
+        if ($name === '' && isset($property['property_title']) && is_string($property['property_title'])) {
+            $name = trim($property['property_title']);
+        }
+
+        if ($name === '') {
+            return '';
+        }
+
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($name, 'UTF-8');
+        }
+
+        return strtolower($name);
+    };
+
+    $getCompletionDateTimestamp = static function (array $property): ?int {
+        if (empty($property['completion_date']) || !is_string($property['completion_date'])) {
+            return null;
+        }
+
+        $timestamp = strtotime($property['completion_date']);
+
+        return $timestamp !== false ? $timestamp : null;
+    };
+
+    $getCreatedAtTimestamp = static function (array $property): ?int {
+        if (empty($property['created_at']) || !is_string($property['created_at'])) {
+            return null;
+        }
+
+        $timestamp = strtotime($property['created_at']);
+
+        return $timestamp !== false ? $timestamp : null;
+    };
+
+    $getPriceValue = static function (array $property) use ($parsePriceToNumber): ?float {
+        return $parsePriceToNumber($property['starting_price'] ?? null);
+    };
+
+    switch ($sortOption) {
+        case 'price_desc':
+            usort($filteredProperties, static function (array $a, array $b) use ($getPriceValue): int {
+                $priceA = $getPriceValue($a);
+                $priceB = $getPriceValue($b);
+
+                if ($priceA === $priceB) {
+                    return 0;
+                }
+
+                if ($priceA === null) {
+                    return 1;
+                }
+
+                if ($priceB === null) {
+                    return -1;
+                }
+
+                return $priceB <=> $priceA;
+            });
+            break;
+
+        case 'price_asc':
+            usort($filteredProperties, static function (array $a, array $b) use ($getPriceValue): int {
+                $priceA = $getPriceValue($a);
+                $priceB = $getPriceValue($b);
+
+                if ($priceA === $priceB) {
+                    return 0;
+                }
+
+                if ($priceA === null) {
+                    return 1;
+                }
+
+                if ($priceB === null) {
+                    return -1;
+                }
+
+                return $priceA <=> $priceB;
+            });
+            break;
+
+        case 'name_asc':
+            usort($filteredProperties, static function (array $a, array $b) use ($getComparableName): int {
+                $nameA = $getComparableName($a);
+                $nameB = $getComparableName($b);
+
+                if ($nameA === $nameB) {
+                    return 0;
+                }
+
+                if ($nameA === '') {
+                    return 1;
+                }
+
+                if ($nameB === '') {
+                    return -1;
+                }
+
+                return strcmp($nameA, $nameB);
+            });
+            break;
+
+        case 'oldest':
+            usort($filteredProperties, static function (array $a, array $b) use ($getCreatedAtTimestamp): int {
+                $createdA = $getCreatedAtTimestamp($a);
+                $createdB = $getCreatedAtTimestamp($b);
+
+                if ($createdA === $createdB) {
+                    return 0;
+                }
+
+                if ($createdA === null) {
+                    return 1;
+                }
+
+                if ($createdB === null) {
+                    return -1;
+                }
+
+                return $createdA <=> $createdB;
+            });
+            break;
+
+        case 'completion_date':
+            usort($filteredProperties, static function (array $a, array $b) use ($getCompletionDateTimestamp): int {
+                $completionA = $getCompletionDateTimestamp($a);
+                $completionB = $getCompletionDateTimestamp($b);
+
+                if ($completionA === $completionB) {
+                    return 0;
+                }
+
+                if ($completionA === null) {
+                    return 1;
+                }
+
+                if ($completionB === null) {
+                    return -1;
+                }
+
+                return $completionA <=> $completionB;
+            });
+            break;
+
+        case 'newest':
+        default:
+            usort($filteredProperties, static function (array $a, array $b) use ($getCreatedAtTimestamp): int {
+                $createdA = $getCreatedAtTimestamp($a);
+                $createdB = $getCreatedAtTimestamp($b);
+
+                if ($createdA === $createdB) {
+                    return 0;
+                }
+
+                if ($createdA === null) {
+                    return 1;
+                }
+
+                if ($createdB === null) {
+                    return -1;
+                }
+
+                return $createdB <=> $createdA;
+            });
+            break;
+    }
+    $propertyCount = count($filteredProperties);
+
+    if ($propertyCount === 0) {
+        $currentPage = 1;
+        $totalPages = 1;
+        $offset = 0;
+        $buyProperties = [];
+    } else {
+        $totalPages = (int)ceil($propertyCount / $itemsPerPage);
+        if ($currentPage > $totalPages) {
+            $currentPage = $totalPages;
+        }
+
+        $offset = ($currentPage - 1) * $itemsPerPage;
+        $buyProperties = array_slice($filteredProperties, $offset, $itemsPerPage);
+    }
+} catch (Throwable $e) {
+    $buyProperties = [];
+    $propertyCount = 0;
+    $totalPages = 1;
+    $currentPage = 1;
+    $offset = 0;
+}
+
+$pageStart = $propertyCount > 0 ? $offset + 1 : 0;
+$pageEnd = $propertyCount > 0 ? min($offset + count($buyProperties), $propertyCount) : 0;
+$propertyLabel = $propertyCount === 1 ? 'property' : 'properties';
+$updatedLabel = date('F j, Y');
+
+$uploadsBasePath = 'admin/assets/uploads/properties/';
+$legacyUploadsPrefix = 'assets/uploads/properties/';
+$normalizeImagePath = static function (?string $path) use ($uploadsBasePath, $legacyUploadsPrefix): ?string {
+    if (!is_string($path)) {
+        return null;
+    }
+
+    $path = trim(str_replace('\\', '/', $path));
+    if ($path === '') {
+        return null;
+    }
+
+    if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://') || str_starts_with($path, '//')) {
+        return $path;
+    }
+
+    $path = ltrim($path, '/');
+
+    if (str_starts_with($path, $uploadsBasePath)) {
+        return $path;
+    }
+
+    if (str_starts_with($path, $legacyUploadsPrefix)) {
+        return $uploadsBasePath . substr($path, strlen($legacyUploadsPrefix));
+    }
+
+    return $uploadsBasePath . $path;
+};
+
+$title = 'Buy Properties in Dubai | Luxury Apartments & Villas for Sale';
+
+$minPriceOptions = [
+    '' => 'Select Min',
+    '300000' => 'AED 300,000',
+    '500000' => 'AED 500,000',
+    '1000000' => 'AED 1,000,000',
+    '5000000' => 'AED 5,000,000',
+    '10000000' => 'AED 10,000,000',
+    '20000000' => 'AED 20,000,000',
+];
+
+$maxPriceOptions = [
+    '' => 'Select Max',
+    '1000000' => 'AED 1,000,000',
+    '5000000' => 'AED 5,000,000',
+    '10000000' => 'AED 10,000,000',
+    '20000000' => 'AED 20,000,000',
+    '30000000' => 'AED 30,000,000',
+    '50000000' => 'AED 50,000,000+',
+];
+
+$filterQueryParams = [];
+foreach (['q', 'project_name', 'location', 'property_type', 'bedrooms', 'location_query', 'completion_year', 'min_price', 'max_price', 'sort'] as $key) {
+    $value = $filters[$key] ?? '';
+    if ($value !== '' && $value !== null) {
+        $filterQueryParams[$key] = (string)$value;
+    }
+}
+
+$buildPageUrl = static function (int $page) use ($filterQueryParams): string {
+    $params = $filterQueryParams;
+    $params['page'] = $page;
+
+    return '?' . http_build_query($params);
+};
 
 $meta_tags = '
     <!-- Basic Meta -->
-    <meta name="description" content="Buy luxury apartments, villas & off-plan homes in Dubai with houzzhunt. Handpicked listings, expert advice & high-ROI picks tailored to your goals.">
-    <meta name="keywords" content="buy apartment in downtown dubai, buy villa in palm jumeirah, buy flat in jumeirah village circle, buy townhouse in arabian ranches, buy home in business bay, buy property in dubai marina, buy apartment in dubai creek harbour, buy apartment in emaar beachfront, buy house in mudon, buy home in dubai hills estate, buy apartment in city walk, buy studio in sports city dubai, buy villa in damac lagoons, buy 1 bhk in motor city, buy 2 bhk in jumeirah lake towers, buy 3 bhk in mirdif dubai, buy luxury home in tilal al ghaf, buy apartment in arjan dubai, buy home in al barari, buy townhouse in nad al sheba, buy flat in silicon oasis, buy apartment in jumeirah beach residence, buy villa in the springs dubai, buy house in discovery gardens, buy townhouse in the villa dubailand, buy apartment in bluewaters island, buy property in meadows dubai, buy flat in greens dubai, buy home in international city, buy 2 bhk in al furjan, buy property in remraam, buy villa in jumeirah park, buy house in al warqaa, buy apartment in dubai land, buy townhouse in al reem, buy apartment in deira dubai, buy flat in bur dubai, buy home in al quoz, buy villa in al khawaneej, buy apartment in meydan, buy house in dubai south, buy apartment in jvc dubai, buy home in town square dubai, buy villa in al barsha, buy apartment in al nahda dubai, buy apartment in international city, buy townhouse in the lakes dubai, buy apartment in al wasl, buy apartment in zabeel dubai, buy villa in jebel ali, buy property in motor city, buy apartment in dubai science park, buy flat in tecom dubai, buy property in al mankhool, buy home in ras al khor, buy apartment in al satwa, buy villa in warsan village, buy house in culture village, buy property in al qouz, 2 bhk apartment for sale in dubai, 3 bhk apartment for sale in dubai, 4 bhk apartment for sale in dubai, studio apartment for sale in dubai, duplex for sale in dubai, penthouse for sale in dubai, villa for sale with private pool dubai, luxury apartment for sale in dubai, townhouse for sale in dubai, mansions for sale in dubai, buy property in dubai, buy apartment in dubai, buy villa in dubai, buy townhouse in dubai, buy penthouse in dubai, buy off-plan property in dubai, dubai off-plan apartments, dubai off-plan villas for sale, dubai real estate for sale, dubai property investment, luxury homes for sale dubai, new projects in dubai, buy 1 bhk in dubai, buy 2 bhk in dubai, buy 3 bhk in dubai, ready to move homes dubai, dubai property price trends, best places to invest in dubai, off-plan property with payment plan, zero commission property dubai, dubai mortgage options, dubai property listings, ready property for sale dubai, dubai apartments with high roi, dubai residential property, investment property in dubai, dubai real estate agency, dubai property market, real estate brokers in dubai, off-plan payment plan dubai, houzzhunt, houzzhunt real estate, houzzhunt dubai, houzzhunt buy property, buy dubai property hh, houzzhunt apartments buy, buy villa dubai houzzhunt, houzzhunt property deals, houzzhunt real estate buy, hh premium homes dubai, houzzhunt homes for sale, luxury buy houzzhunt, houzzhunt dubai listings, buy with houzzhunt, dubai homes hh, houzzhunt ready properties, hh investment properties, houzzhunt dubai realty">
+
+    <meta name="description" content="Buy luxury apartments, villas & ready homes in Dubai with houzzhunt. Verified listings, expert advice & high-ROI picks tailored to your goals.">
+    <meta name="keywords" content="buy apartment in downtown dubai, buy villa in palm jumeirah, buy flat in jumeirah village circle, buy townhouse in arabian ranches, buy home in business bay, buy property in dubai marina, buy apartment in dubai creek harbour, buy apartment in emaar beachfront, buy house in mudon, buy home in dubai hills estate, buy apartment in city walk, buy studio in sports city dubai, buy villa in damac lagoons, buy 1 bhk in motor city, buy 2 bhk in jumeirah lake towers, buy 3 bhk in mirdif dubai, buy luxury home in tilal al ghaf, buy apartment in arjan dubai, buy home in al barari, buy townhouse in nad al sheba, buy flat in silicon oasis, buy apartment in jumeirah beach residence, buy villa in the springs dubai, buy house in discovery gardens, buy townhouse in the villa dubailand, buy apartment in bluewaters island, buy property in meadows dubai, buy flat in greens dubai, buy home in international city, buy 2 bhk in al furjan, buy property in remraam, buy villa in jumeirah park, buy house in al warqaa, buy apartment in dubai land, buy townhouse in al reem, buy apartment in deira dubai, buy flat in bur dubai, buy home in al quoz, buy villa in al khawaneej, buy apartment in meydan, buy house in dubai south, buy apartment in jvc dubai, buy home in town square dubai, buy villa in al barsha, buy apartment in al nahda dubai, buy apartment in international city, buy townhouse in the lakes dubai, buy apartment in al wasl, buy apartment in zabeel dubai, buy villa in jebel ali, buy property in motor city, buy apartment in dubai science park, buy flat in tecom dubai, buy property in al mankhool, buy home in ras al khor, buy apartment in al satwa, buy villa in warsan village, buy house in culture village, buy property in al qouz, ready property for sale dubai, move-in ready homes dubai, houzzhunt buy properties, houzzhunt luxury homes, houzzhunt ready apartments, houzzhunt villas for sale">
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="houzzhunt | Explore Properties, Real Estate Listings & Investment Opportunities">
@@ -24,42 +520,545 @@ include 'includes/common-header.php';
 include 'includes/navbar.php';
 ?>
 
-<!-- page header start -->
-<div class="page-header-section" style="background-image: url(assets/images/banner/buy-properties-banner.webp);">
+
+
+<!-- parent: .hh-hero-01 -->
+<div class="hh-hero-01" style="background-image: url(assets/images/banner/buy-properties-banner.webp);">
     <div class="container">
+        <!-- Hero copy -->
         <div class="row">
-            <div class="col-lg-7">
-                <div class="page-header-heading animate fadeInLeft wow" data-wow-duration="2000ms">
-                    <h2>Buy Properties</h2>
-                    <p class="lead">Explore Dubai’s most desirable properties for sale. Verified listings, expert guidance, and end-to-end support.</p>
+            <div class="col-12">
+                <header>
+                    <h1>Premium Properties for Sale in Dubai</h1>
+                    <p>Explore handpicked ready and resale homes across Dubai’s most desirable communities.
+                        Verified listings, expert guidance, and tailored investment advice from houzzhunt.</p>
+                </header>
+            </div>
+        </div>
+
+        <!-- Property Details Filter Sections -->
+        <div class="row">
+            <div class="col-12">
+                <form id="buy-filter-form" method="get" action="buy-properties.php">
+                    <input type="hidden" name="page" value="1">
+                    <div class="container">
+                        <div class="row align-items-center mb-4">
+                            <!-- Search input -->
+                            <!-- <div class="col-lg-3">
+
+                                <label>
+                                    <span>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                            class="lucide lucide-building">
+                                            <rect x="4" y="2" width="16" height="20" rx="2" ry="2"></rect>
+                                            <path d="M9 22V12h6v10"></path>
+                                        </svg>
+                                        Project Name
+                                    </span>
+                                    <input type="search" name="q" placeholder="Enter Project Name" value="<?= htmlspecialchars($filters['q'], ENT_QUOTES, 'UTF-8') ?>">
+                                </label>
+
+                            </div> -->
+
+                            <!-- Project Name -->
+                            <div class="col-lg-3">
+
+                                <label>
+                                    <span>
+                                        <!-- blueprint -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                            class="lucide lucide-layout-dashboard">
+                                            <rect x="3" y="3" width="7" height="9" rx="1" />
+                                            <rect x="14" y="3" width="7" height="5" rx="1" />
+                                            <rect x="14" y="10" width="7" height="11" rx="1" />
+                                            <rect x="3" y="15" width="7" height="6" rx="1" />
+                                        </svg>
+                                        Project Name
+                                    </span>
+                                    <input type="search" name="project_name" placeholder="Enter Project Name" value="<?= htmlspecialchars($filters['project_name'], ENT_QUOTES, 'UTF-8') ?>">
+                                </label>
+
+                            </div>
+
+                            <!-- Location -->
+                            <div class="col-lg-3">
+                                <label>
+                                    <span>
+                                        <!-- location pin -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin w-4 h-4 mr-1" data-lov-id="src/components/PropertyCard.tsx:63:12" data-lov-name="MapPin" data-component-path="src/components/PropertyCard.tsx" data-component-line="63" data-component-file="PropertyCard.tsx" data-component-name="MapPin" data-component-content="%7B%22className%22%3A%22w-4%20h-4%20mr-1%22%7D">
+                                            <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"></path>
+                                            <circle cx="12" cy="10" r="3"></circle>
+                                        </svg>
+                                        Location
+                                    </span>
+                                    <select class="select-dropDownClass" name="location">
+                                        <option value="">Select Location</option>
+                                        <?php foreach ($filterOptions['locations'] as $locationOption): ?>
+                                            <option value="<?= htmlspecialchars($locationOption, ENT_QUOTES, 'UTF-8') ?>" <?= $filters['location'] === $locationOption ? 'selected' : '' ?>><?= htmlspecialchars($locationOption, ENT_QUOTES, 'UTF-8') ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+
+                                </label>
+                            </div>
+
+                            <!-- Type -->
+                            <div class="col-lg-3">
+                                <label>
+                                    <span>
+                                        <!-- home -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-house w-4 h-4" data-lov-id="src/components/SearchFilters.tsx:34:12" data-lov-name="Home" data-component-path="src/components/SearchFilters.tsx" data-component-line="34" data-component-file="SearchFilters.tsx" data-component-name="Home" data-component-content="%7B%22className%22%3A%22w-4%20h-4%22%7D">
+                                            <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"></path>
+                                            <path d="M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path>
+                                        </svg>
+                                        Type
+                                    </span>
+                                    <select id="property-type" class="select-dropDownClass" name="property_type">
+                                        <option value="">Property Type</option>
+                                        <?php foreach ($filterOptions['property_types'] as $typeOption): ?>
+                                            <option value="<?= htmlspecialchars($typeOption, ENT_QUOTES, 'UTF-8') ?>" <?= $filters['property_type'] === $typeOption ? 'selected' : '' ?>><?= htmlspecialchars($typeOption, ENT_QUOTES, 'UTF-8') ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+
+                                </label>
+                            </div>
+
+                            <!-- Bedrooms -->
+                            <div class="col-lg-3">
+                                <label>
+                                    <span>
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-bed w-4 h-4" data-lov-id="src/components/PropertyCard.tsx:71:14" data-lov-name="Bed" data-component-path="src/components/PropertyCard.tsx" data-component-line="71" data-component-file="PropertyCard.tsx" data-component-name="Bed" data-component-content="%7B%22className%22%3A%22w-4%20h-4%22%7D">
+                                            <path d="M2 4v16"></path>
+                                            <path d="M2 8h18a2 2 0 0 1 2 2v10"></path>
+                                            <path d="M2 17h20"></path>
+                                            <path d="M6 8v9"></path>
+                                        </svg>
+                                        Bedrooms
+                                    </span>
+                                    <select class="select-dropDownClass" name="bedrooms">
+                                        <option value="">All Bedrooms</option>
+                                        <?php foreach ($filterOptions['bedrooms'] as $bedroomValue => $bedroomLabel): ?>
+                                            <option value="<?= htmlspecialchars((string)$bedroomValue, ENT_QUOTES, 'UTF-8') ?>"<?= (string)$filters['bedrooms'] === (string)$bedroomValue ? 'selected' : '' ?>><?= htmlspecialchars($bedroomLabel, ENT_QUOTES, 'UTF-8') ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                            </div>
+
+                        </div>
+
+                        <div class="row align-items-center">
+
+                            <!-- Search input -->
+                            <div class="col-lg-3">
+
+                                <label>
+                                    <span>
+                                        <!-- search -->
+                                        <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path d="M21 21 15.8 15.8M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" fill="none" stroke="currentColor" stroke-width="2" />
+                                        </svg>
+                                        Search Location
+                                    </span>
+                                    <input type="search" name="location_query" placeholder="Enter Property Location.." value="<?= htmlspecialchars($filters['location_query'], ENT_QUOTES, 'UTF-8') ?>">
+                                </label>
+                            </div>
+
+                            <!-- Completion Year -->
+                            <div class="col-lg-3">
+                                <label>
+                                    <span>
+                                        <!-- Completion Year pin -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                            class="lucide lucide-calendar w-4 h-4 mr-1">
+                                            <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                                            <line x1="16" y1="2" x2="16" y2="6" />
+                                            <line x1="8" y1="2" x2="8" y2="6" />
+                                            <line x1="3" y1="10" x2="21" y2="10" />
+                                        </svg>
+                                        Completion Year
+                                    </span>
+                                    <select class="select-dropDownClass" name="completion_year">
+                                        <option value="">Completion Year</option>
+                                        <?php foreach ($filterOptions['completion_years'] as $completionYear): ?>
+                                            <option value="<?= (int)$completionYear ?>" <?= (string)$filters['completion_year'] === (string)$completionYear ? 'selected' : '' ?>><?= (int)$completionYear ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+
+
+                                </label>
+                            </div>
+
+                            <!-- Price Range -->
+                            <div class="col-lg-2">
+                                <label>
+                                    <span>
+                                        <!-- dollar icon -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                            class="lucide lucide-dollar-sign w-4 h-4">
+                                            <line x1="12" x2="12" y1="2" y2="22"></line>
+                                            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                        </svg>
+                                        Min Price
+                                    </span>
+                                    <select class="select-dropDownClass" name="min_price">
+                                        <?php foreach ($minPriceOptions as $value => $label): ?>
+                                            <?php $optionValue = (string)$value; ?>
+                                            <option value="<?= htmlspecialchars($optionValue, ENT_QUOTES, 'UTF-8') ?>" <?= (string)$filters['min_price'] === $optionValue ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                            </div>
+
+                            <div class="col-lg-2">
+                                <label>
+                                    <span>
+                                        <!-- dollar icon -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                            viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                                            class="lucide lucide-dollar-sign w-4 h-4">
+                                            <line x1="12" x2="12" y1="2" y2="22"></line>
+                                            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path>
+                                        </svg>
+                                        Max Price
+                                    </span>
+                                    <select class="select-dropDownClass" name="max_price">
+                                        <?php foreach ($maxPriceOptions as $value => $label): ?>
+                                            <?php $optionValue = (string)$value; ?>
+                                            <option value="<?= htmlspecialchars($optionValue, ENT_QUOTES, 'UTF-8') ?>" <?= (string)$filters['max_price'] === $optionValue ? 'selected' : '' ?>><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?></option>
+                                        <?php endforeach; ?>
+                                    </select>
+                                </label>
+                            </div>
+
+                            <!-- Actions -->
+                            <div class="col-lg-1">
+                                <div class="mt-4">
+                                    <button type="submit">Search</button>
+                                </div>
+                            </div>
+
+                            <!-- Reset Button -->
+                            <div class="col-lg-1">
+                                <div class="mt-4">
+                                    <button
+                                        type="button"
+                                        class="btn btn-danger"
+                                        style="background-color: #d01f28; border: none; height: 48px; padding: 0 24px;"
+                                        onclick="window.location.href='buy-properties.php';"
+                                    >
+                                        Reset
+                                    </button>
+                                </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+                </form>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+
+<!-- parent: .hh-properties-01 -->
+<div class="hh-properties-01">
+    <div class="container">
+
+        <!-- Heading + sort -->
+        <div class="row">
+            <div class="col-12">
+                <div class="hh-properties-01-head">
+                    <div>
+                        <h2>Featured Buy Properties</h2>
+                        <p>
+                            <?php if ($propertyCount > 0): ?>
+                                Showing <?= htmlspecialchars((string)$pageStart, ENT_QUOTES, 'UTF-8') ?>–<?= htmlspecialchars((string)$pageEnd, ENT_QUOTES, 'UTF-8') ?> of <?= htmlspecialchars((string)$propertyCount, ENT_QUOTES, 'UTF-8') ?> <?= htmlspecialchars($propertyLabel, ENT_QUOTES, 'UTF-8') ?> • Updated <?= htmlspecialchars($updatedLabel, ENT_QUOTES, 'UTF-8') ?>
+                            <?php else: ?>
+                                Showing 0 <?= htmlspecialchars($propertyLabel, ENT_QUOTES, 'UTF-8') ?> • Updated <?= htmlspecialchars($updatedLabel, ENT_QUOTES, 'UTF-8') ?>
+                            <?php endif; ?>
+                        </p>
+                    </div>
+                    <div>
+                        <label>
+                            Sort by:
+                            <select
+                                name="sort"
+                                form="buy-filter-form"
+                                onchange="document.getElementById('buy-filter-form').submit();"
+                            >
+                                <option value="price_desc" <?= $filters['sort'] === 'price_desc' ? 'selected' : '' ?>>Price: High to Low</option>
+                                <option value="price_asc" <?= $filters['sort'] === 'price_asc' ? 'selected' : '' ?>>Price: Low to High</option>
+                                <option value="name_asc" <?= $filters['sort'] === 'name_asc' ? 'selected' : '' ?>>A to Z</option>
+                                <option value="newest" <?= $filters['sort'] === 'newest' || $filters['sort'] === '' ? 'selected' : '' ?>>Newly</option>
+                                <option value="oldest" <?= $filters['sort'] === 'oldest' ? 'selected' : '' ?>>Oldest</option>
+                                <option value="completion_date" <?= $filters['sort'] === 'completion_date' ? 'selected' : '' ?>>Date</option>
+                            </select>
+                        </label>
+                        <div class="hh-properties-01-toggle">
+                            <button type="button" data-view="grid" class="active">
+                                <!-- grid icon -->
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-grid3x3 w-4 h-4" data-lov-id="src/components/PropertyListing.tsx:142:16" data-lov-name="Grid3X3" data-component-path="src/components/PropertyListing.tsx" data-component-line="142" data-component-file="PropertyListing.tsx" data-component-name="Grid3X3" data-component-content="%7B%22className%22%3A%22w-4%20h-4%22%7D">
+                                    <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+                                    <path d="M3 9h18"></path>
+                                    <path d="M3 15h18"></path>
+                                    <path d="M9 3v18"></path>
+                                    <path d="M15 3v18"></path>
+                                </svg>
+                            </button>
+                            <button type="button" data-view="list">
+                                <!-- list icon -->
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list w-4 h-4" data-lov-id="src/components/PropertyListing.tsx:145:16" data-lov-name="List" data-component-path="src/components/PropertyListing.tsx" data-component-line="145" data-component-file="PropertyListing.tsx" data-component-name="List" data-component-content="%7B%22className%22%3A%22w-4%20h-4%22%7D">
+                                    <path d="M3 12h.01"></path>
+                                    <path d="M3 18h.01"></path>
+                                    <path d="M3 6h.01"></path>
+                                    <path d="M8 12h13"></path>
+                                    <path d="M8 18h13"></path>
+                                    <path d="M8 6h13"></path>
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <ul class="breadcrumb">
-            <li>
-                <a href="index.php">Home</a>
-            </li>
-            <li>
-                <img src="assets/images/about/arrow-brudcrumb.svg" alt="icon">
-            </li>
-            <li>
-                <span>Buy Properties</span>
-            </li>
-        </ul>
+
+        <!-- Cards -->
+        <div class="row hh-properties-01-grid">
+            <?php if ($buyProperties): ?>
+                <?php foreach ($buyProperties as $property): ?>
+                    <?php
+                    $heroBanner = $normalizeImagePath($property['hero_banner'] ?? null) ?? '';
+                    $galleryImages = [];
+                    if (!empty($property['gallery_images'])) {
+                        $decodedGallery = json_decode((string)$property['gallery_images'], true);
+                        if (is_array($decodedGallery)) {
+                            foreach ($decodedGallery as $imagePath) {
+                                $normalized = $normalizeImagePath(is_string($imagePath) ? $imagePath : null);
+                                if ($normalized !== null) {
+                                    $galleryImages[] = $normalized;
+                                }
+                            }
+                        }
+                    }
+
+                    $primaryImage = $heroBanner !== '' ? $heroBanner : ($galleryImages[0] ?? 'assets/images/properties-listing/breez-by-danube-list.webp');
+                    $projectName = trim((string)($property['project_name'] ?? ''));
+                    if ($projectName === '') {
+                        $projectName = trim((string)($property['property_title'] ?? ''));
+                    }
+
+                    $specs = [];
+                    $bedroomValue = isset($property['bedroom']) ? trim((string)$property['bedroom']) : '';
+                    if ($bedroomValue !== '') {
+                        if (is_numeric($bedroomValue)) {
+                            $bedroomLabel = (int)$bedroomValue === 1 ? '1 Bed' : $bedroomValue . ' Beds';
+                        } elseif (stripos($bedroomValue, 'bed') !== false || stripos($bedroomValue, 'studio') !== false) {
+                            $bedroomLabel = $bedroomValue;
+                        } else {
+                            $bedroomLabel = $bedroomValue . ' Beds';
+                        }
+                        $specs[] = ['icon' => 'assets/icons/bed.png', 'text' => $bedroomLabel];
+                    }
+                    if (!empty($property['bathroom'])) {
+                        $specs[] = ['icon' => 'assets/icons/bathroom.png', 'text' => trim((string)$property['bathroom']) . ' Baths'];
+                    }
+                    if (!empty($property['total_area'])) {
+                        $specs[] = ['icon' => 'assets/icons/area.png', 'text' => trim((string)$property['total_area'])];
+                    }
+
+                    $priceCurrency = '';
+                    $priceValue = '';
+                    $rawPrice = trim((string)($property['starting_price'] ?? ''));
+                    if ($rawPrice !== '') {
+                        $priceDisplay = stripos($rawPrice, 'aed') === false ? 'AED ' . $rawPrice : $rawPrice;
+                        if (stripos($priceDisplay, 'aed') === 0) {
+                            $priceCurrency = 'AED';
+                            $priceValue = trim(substr($priceDisplay, 3));
+                        } else {
+                            $priceValue = $priceDisplay;
+                        }
+                    }
+                    ?>
+                    <div class="col-12 col-md-6 col-lg-4">
+                        <a href="buy-properties-details.php?id=<?= (int)($property['id'] ?? 0) ?>" class="property-link">
+                            <article>
+                                <div class="hh-properties-01-img">
+                                    <img src="<?= htmlspecialchars($primaryImage, ENT_QUOTES, 'UTF-8') ?>" alt="<?= htmlspecialchars($projectName !== '' ? $projectName : 'Project', ENT_QUOTES, 'UTF-8') ?>">
+                                    <div class="hh-properties-01-tags">
+                                        <?php if (!empty($property['project_status'])): ?>
+                                            <span class="green"><?= htmlspecialchars($property['project_status'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <?php endif; ?>
+                                        <?php if (!empty($property['property_type'])): ?>
+                                            <span><?= htmlspecialchars($property['property_type'], ENT_QUOTES, 'UTF-8') ?></span>
+                                        <?php endif; ?>
+                                    </div>
+                                    <button type="button" class="hh-properties-01-fav" aria-label="Save">♥</button>
+                                </div>
+                                <div class="hh-properties-01-body">
+                                    <h3><?= htmlspecialchars($projectName !== '' ? $projectName : 'Untitled Project', ENT_QUOTES, 'UTF-8') ?></h3>
+                                    <?php if (!empty($property['property_location'])): ?>
+                                        <p><img src="assets/icons/location.png" width="16" alt=""> <?= htmlspecialchars($property['property_location'], ENT_QUOTES, 'UTF-8') ?></p>
+                                    <?php endif; ?>
+                                    <?php if ($specs): ?>
+                                        <ul>
+                                            <?php foreach ($specs as $spec): ?>
+                                                <li><img src="<?= htmlspecialchars($spec['icon'], ENT_QUOTES, 'UTF-8') ?>" width="16" alt=""> <?= htmlspecialchars($spec['text'], ENT_QUOTES, 'UTF-8') ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php endif; ?>
+                                    <div class="hh-properties-01-foot">
+                                        <?php if ($priceValue !== ''): ?>
+                                            <strong>
+                                                <?php if ($priceCurrency !== ''): ?>
+                                                    <span><?= htmlspecialchars($priceCurrency, ENT_QUOTES, 'UTF-8') ?></span>
+                                                <?php endif; ?>
+                                                <?= htmlspecialchars($priceValue, ENT_QUOTES, 'UTF-8') ?>
+                                            </strong>
+                                        <?php else: ?>
+                                            <strong>Price on request</strong>
+                                        <?php endif; ?>
+                                        <span class="details-link">View Details</span>
+                                    </div>
+                                </div>
+                            </article>
+                        </a>
+                    </div>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <div class="col-12">
+                    <p class="mb-0">No buy properties available right now. Please check back soon.</p>
+                </div>
+            <?php endif; ?>
+        </div>
+
+        <?php if ($totalPages > 1): ?>
+            <nav class="hh-pagination" aria-label="Buy properties pagination">
+                <ul>
+                    <li class="prev<?= $currentPage <= 1 ? ' disabled' : '' ?>">
+                        <?php if ($currentPage > 1): ?>
+                            <a href="<?= htmlspecialchars($buildPageUrl($currentPage - 1), ENT_QUOTES, 'UTF-8') ?>">Previous</a>
+                        <?php else: ?>
+                            <span>Previous</span>
+                        <?php endif; ?>
+                    </li>
+
+                    <?php for ($page = 1; $page <= $totalPages; $page++): ?>
+                        <li class="<?= $page === $currentPage ? 'active' : '' ?>">
+                            <?php if ($page === $currentPage): ?>
+                                <span><?= (int)$page ?></span>
+                            <?php else: ?>
+                                <a href="<?= htmlspecialchars($buildPageUrl($page), ENT_QUOTES, 'UTF-8') ?>"><?= (int)$page ?></a>
+                            <?php endif; ?>
+                        </li>
+                    <?php endfor; ?>
+
+                    <li class="next<?= $currentPage >= $totalPages ? ' disabled' : '' ?>">
+                        <?php if ($currentPage < $totalPages): ?>
+                            <a href="<?= htmlspecialchars($buildPageUrl($currentPage + 1), ENT_QUOTES, 'UTF-8') ?>">Next</a>
+                        <?php else: ?>
+                            <span>Next</span>
+                        <?php endif; ?>
+                    </li>
+                </ul>
+            </nav>
+        <?php endif; ?>
+
     </div>
 </div>
-<!-- page header start -->
-
-<section style="padding: 100px 0px; text-align: center;">
-    <div class="container">
-        <h2 style="font-size:60px; font-weight:500px;" class="heading-title"><span>Coming Soon</span></h2>
-        <p style="font-size: 16px; max-width: 600px; margin: 0 auto;">
-            We’re working on something amazing! <br> Stay tuned for updates and announcements from houzzhunt.
-        </p>
-    </div>
-</section>
 
 
+<script>
+    document.querySelectorAll('.hh-properties-01-toggle button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.hh-properties-01-toggle button')
+                .forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+
+            const grid = document.querySelector('.hh-properties-01-grid');
+            if (btn.dataset.view === 'list') {
+                grid.classList.add('list-view');
+            } else {
+                grid.classList.remove('list-view');
+            }
+        });
+    });
+</script>
+
+<style>
+    .hh-properties-01-grid.list-view .col-12 {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    .hh-properties-01-grid.list-view article {
+        display: flex;
+        gap: 20px;
+    }
+
+    .hh-properties-01-grid.list-view .hh-properties-01-img {
+        flex: 0 0 40%;
+    }
+
+    .hh-properties-01-grid.list-view .hh-properties-01-body {
+        flex: 1;
+    }
+
+    .hh-pagination {
+        margin-top: 40px;
+        text-align: center;
+        position: inherit;
+    }
+
+    .hh-pagination ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: inline-flex;
+        gap: 8px;
+    }
+
+    .hh-pagination li {
+        display: inline-flex;
+    }
+
+    .hh-pagination a,
+    .hh-pagination span {
+        display: inline-block;
+        padding: 8px 14px;
+        border: 1px solid #d0d4dc;
+        border-radius: 999px;
+        color: #004a44;
+        text-decoration: none;
+        font-size: 14px;
+        transition: all 0.2s ease-in-out;
+    }
+
+    .hh-pagination a:hover {
+        background-color: #004a44;
+        color: #fff;
+    }
+
+    .hh-pagination li.active span {
+        background-color: #004a44;
+        color: #fff;
+        cursor: default;
+    }
+
+    .hh-pagination li.disabled span {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+</style>
 
 
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- replace the buy properties landing page with a fully functional listing experience that mirrors the offplan UI while sourcing data from the buy_properties_list table
- add meta content, filtering, pagination, and styling tailored for ready/secondary properties, including updated hero copy and empty-state messaging
- introduce a dedicated buy property details page leveraging the existing property detail layout but pointing to buy inventory assets and navigation

## Testing
- php -l buy-properties.php
- php -l buy-properties-details.php

------
https://chatgpt.com/codex/tasks/task_e_68e0cb1229d0832ab4d3e034a54955d6