### PR TITLE
Add off-plan lead capture and admin reporting

### DIFF
--- a/admin/includes/render.php
+++ b/admin/includes/render.php
@@ -100,6 +100,7 @@ function render_sidebar(string $active): void
       'icon'  => 'bi-person-lines-fill',
       'label' => 'All Type Leads',
       'items' => [
+        'offplan-leads'  => ['href' => 'offplan_leads.php', 'label' => 'Off-Plan Leads'],
         'contact-form'    => ['href' => 'contact_form_submissions.php', 'label' => 'Contact Submissions'],
         'popup-form'      => ['href' => 'popup_form_submissions.php', 'label' => 'Popup Submissions'],
         'mortgage-leads'  => ['href' => 'mortgage_leads.php', 'label' => 'Mortgage Leads'],

--- a/admin/offplan_leads.php
+++ b/admin/offplan_leads.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/bootstrap.php';
+require_once __DIR__ . '/includes/render.php';
+require_once __DIR__ . '/includes/auth.php';
+
+process_logout();
+
+if (!is_authenticated()) {
+  header('Location: login.php');
+  exit;
+}
+
+$pdo = db();
+$perPage = 10;
+$page = filter_input(
+  INPUT_GET,
+  'page',
+  FILTER_VALIDATE_INT,
+  ['options' => ['default' => 1, 'min_range' => 1]]
+);
+$offset = ($page - 1) * $perPage;
+$totalLeads = 0;
+$totalPages = 0;
+$leads = [];
+$error = null;
+
+try {
+  $countStmt = $pdo->query('SELECT COUNT(*) FROM offplan_leads');
+  $totalLeads = (int) $countStmt->fetchColumn();
+
+  if ($totalLeads > 0) {
+    $totalPages = (int) ceil($totalLeads / $perPage);
+    if ($page > $totalPages) {
+      $page = $totalPages;
+      $offset = ($page - 1) * $perPage;
+    }
+
+    $stmt = $pdo->prepare(
+      'SELECT id, lead_type, property_id, property_title, name, email, phone, country, brochure_url, ip_address, user_agent, created_at '
+      . 'FROM offplan_leads '
+      . 'ORDER BY created_at DESC, id DESC '
+      . 'LIMIT :limit OFFSET :offset'
+    );
+    $stmt->bindValue(':limit', $perPage, PDO::PARAM_INT);
+    $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    $stmt->execute();
+    $leads = $stmt->fetchAll();
+  } else {
+    $page = 1;
+    $offset = 0;
+  }
+} catch (Throwable $e) {
+  error_log('Failed to load off-plan leads: ' . $e->getMessage());
+  $error = 'Unable to load off-plan leads at this time.';
+}
+
+$paginationBasePath = strtok((string) ($_SERVER['REQUEST_URI'] ?? ''), '?') ?: '/offplan_leads.php';
+$paginationQueryParams = $_GET;
+unset($paginationQueryParams['page']);
+$buildPaginationUrl = static function (int $targetPage) use ($paginationBasePath, $paginationQueryParams): string {
+  $params = $paginationQueryParams;
+  $params['page'] = $targetPage;
+  $queryString = http_build_query($params);
+  $url = $paginationBasePath . ($queryString ? '?' . $queryString : '');
+  return $url === '' ? '#' : $url;
+};
+
+render_head('Off-Plan Leads');
+echo '<div class="container-fluid layout">';
+echo '<div class="row g-0">';
+render_sidebar('offplan-leads');
+?>
+<main class="col-12 col-md-9 col-lg-10 content">
+  <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+    <div>
+      <h2 class="title-heading">Off-Plan Leads</h2>
+      <p class="para mb-0">View enquiries captured from off-plan property popups and brochure downloads.</p>
+    </div>
+    <div class="text-lg-end">
+      <span class="badge bg-primary-subtle text-primary fw-semibold">Total leads: <?= number_format($totalLeads) ?></span>
+    </div>
+  </div>
+
+  <?php if ($error): ?>
+    <div class="alert alert-warning" role="alert">
+      <?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?>
+    </div>
+  <?php elseif (!$leads): ?>
+    <div class="alert alert-info" role="alert">
+      No off-plan leads found.
+    </div>
+  <?php else: ?>
+    <div class="box">
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle mb-0">
+          <thead class="table-secondary">
+            <tr>
+              <th scope="col">#</th>
+              <th scope="col">Lead Type</th>
+              <th scope="col">Property</th>
+              <th scope="col">Name</th>
+              <th scope="col">Email</th>
+              <th scope="col">Phone</th>
+              <th scope="col">Country</th>
+              <th scope="col">Brochure</th>
+              <th scope="col">IP Address</th>
+              <th scope="col">User Agent</th>
+              <th scope="col">Submitted</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($leads as $lead): ?>
+              <?php
+                $createdAt = (string) ($lead['created_at'] ?? '');
+                $createdAtFormatted = '—';
+                if ($createdAt !== '') {
+                  try {
+                    $createdAtFormatted = (new DateTimeImmutable($createdAt))->format('d M Y H:i');
+                  } catch (Throwable $e) {
+                    $createdAtFormatted = $createdAt;
+                  }
+                }
+                $leadType = (string) ($lead['lead_type'] ?? '');
+                $leadTypeLabel = match ($leadType) {
+                  'brochure' => 'Brochure Download',
+                  'popup' => 'Popup Enquiry',
+                  default => ($leadType !== '' ? ucfirst($leadType) : '—'),
+                };
+                $propertyTitle = trim((string) ($lead['property_title'] ?? ''));
+                if ($propertyTitle === '' && !empty($lead['property_id'])) {
+                  $propertyTitle = 'Property #' . (int) $lead['property_id'];
+                }
+              ?>
+              <tr>
+                <td><?= (int) $lead['id'] ?></td>
+                <td><?= htmlspecialchars($leadTypeLabel, ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($propertyTitle !== '' ? $propertyTitle : '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars((string) ($lead['name'] ?? ''), ENT_QUOTES, 'UTF-8') ?></td>
+                <td>
+                  <?php if (!empty($lead['email'])): ?>
+                    <a href="mailto:<?= htmlspecialchars($lead['email'], ENT_QUOTES, 'UTF-8') ?>">
+                      <?= htmlspecialchars($lead['email'], ENT_QUOTES, 'UTF-8') ?>
+                    </a>
+                  <?php else: ?>
+                    <span class="text-muted">—</span>
+                  <?php endif; ?>
+                </td>
+                <td><?= htmlspecialchars((string) ($lead['phone'] ?? '—'), ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars((string) ($lead['country'] ?? '—'), ENT_QUOTES, 'UTF-8') ?></td>
+                <td>
+                  <?php if (!empty($lead['brochure_url'])): ?>
+                    <a href="<?= htmlspecialchars($lead['brochure_url'], ENT_QUOTES, 'UTF-8') ?>" target="_blank" rel="noopener">
+                      View
+                    </a>
+                  <?php else: ?>
+                    <span class="text-muted">—</span>
+                  <?php endif; ?>
+                </td>
+                <td><?= htmlspecialchars((string) ($lead['ip_address'] ?? '—'), ENT_QUOTES, 'UTF-8') ?></td>
+                <td class="text-break">
+                  <?php if (!empty($lead['user_agent'])): ?>
+                    <small><?= htmlspecialchars($lead['user_agent'], ENT_QUOTES, 'UTF-8') ?></small>
+                  <?php else: ?>
+                    <span class="text-muted">—</span>
+                  <?php endif; ?>
+                </td>
+                <td><?= htmlspecialchars($createdAtFormatted, ENT_QUOTES, 'UTF-8') ?></td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+      <?php if ($totalPages > 1): ?>
+        <nav aria-label="Off-plan leads pagination" class="mt-3">
+          <ul class="pagination mb-0">
+            <li class="page-item<?= $page <= 1 ? ' disabled' : '' ?>">
+              <?php if ($page <= 1): ?>
+                <span class="page-link">Previous</span>
+              <?php else: ?>
+                <a class="page-link" href="<?= htmlspecialchars($buildPaginationUrl($page - 1), ENT_QUOTES, 'UTF-8') ?>" aria-label="Previous">Previous</a>
+              <?php endif; ?>
+            </li>
+            <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+              <li class="page-item<?= $i === $page ? ' active' : '' ?>"<?php if ($i === $page): ?> aria-current="page"<?php endif; ?>>
+                <?php if ($i === $page): ?>
+                  <span class="page-link"><?= $i ?></span>
+                <?php else: ?>
+                  <a class="page-link" href="<?= htmlspecialchars($buildPaginationUrl($i), ENT_QUOTES, 'UTF-8') ?>"><?= $i ?></a>
+                <?php endif; ?>
+              </li>
+            <?php endfor; ?>
+            <li class="page-item<?= $page >= $totalPages ? ' disabled' : '' ?>">
+              <?php if ($page >= $totalPages): ?>
+                <span class="page-link">Next</span>
+              <?php else: ?>
+                <a class="page-link" href="<?= htmlspecialchars($buildPaginationUrl($page + 1), ENT_QUOTES, 'UTF-8') ?>" aria-label="Next">Next</a>
+              <?php endif; ?>
+            </li>
+          </ul>
+        </nav>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
+</main>
+<?php
+
+echo '</div>';
+echo '</div>';
+render_footer();

--- a/admin/u431421769_monitor_hunt.sql
+++ b/admin/u431421769_monitor_hunt.sql
@@ -155,6 +155,29 @@ INSERT INTO `popup_form` (`id`, `name`, `email`, `phone`, `country`, `ip_address
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `offplan_leads`
+--
+
+CREATE TABLE `offplan_leads` (
+  `id` bigint(20) UNSIGNED NOT NULL,
+  `lead_type` varchar(50) DEFAULT NULL,
+  `property_id` int(11) DEFAULT NULL,
+  `property_title` varchar(255) DEFAULT NULL,
+  `name` varchar(255) DEFAULT NULL,
+  `email` varchar(255) DEFAULT NULL,
+  `phone` varchar(64) DEFAULT NULL,
+  `country` varchar(150) DEFAULT NULL,
+  `brochure_url` varchar(500) DEFAULT NULL,
+  `ip_address` varchar(100) DEFAULT NULL,
+  `user_agent` text DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `lead_type` (`lead_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `properties_list`
 --
 
@@ -272,6 +295,12 @@ ALTER TABLE `contact_form`
 --
 ALTER TABLE `mortgage_leads`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=11;
+
+--
+-- AUTO_INCREMENT for table `offplan_leads`
+--
+ALTER TABLE `offplan_leads`
+  MODIFY `id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT for table `page_access_logs`

--- a/property-details.php
+++ b/property-details.php
@@ -4,7 +4,19 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/includes/config.php';
 
-$propertyId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+hh_session_start();
+
+$propertyId = 0;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $propertyId = isset($_POST['property_id']) ? (int) $_POST['property_id'] : 0;
+}
+
+if ($propertyId <= 0) {
+    $propertyId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+}
+
+$leadFormError = $_SESSION['offplan_lead_error'] ?? null;
+unset($_SESSION['offplan_lead_error']);
 
 if ($propertyId <= 0) {
     http_response_code(404);
@@ -25,6 +37,96 @@ if (!$property) {
     http_response_code(404);
     echo 'Property not found.';
     exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $formType = (string) ($_POST['form_type'] ?? '');
+    if ($formType === 'popup' || $formType === 'brochure') {
+        $redirectUrl = 'property-details.php?id=' . $propertyId
+            . ($formType === 'brochure' ? '#downloadBrochure' : '#propertyEnquirey');
+
+        $nameKey = $formType === 'popup' ? 'name' : 'brochure_name';
+        $emailKey = $formType === 'popup' ? 'email' : 'brochure_email';
+        $countryKey = $formType === 'popup' ? 'country' : 'brochure_country';
+        $phoneKey = $formType === 'popup' ? 'phone' : 'brochure_phone';
+
+        $name = trim((string) ($_POST[$nameKey] ?? ''));
+        $emailInput = trim((string) ($_POST[$emailKey] ?? ''));
+        $emailValidated = filter_var($emailInput, FILTER_VALIDATE_EMAIL);
+        $email = $emailValidated !== false ? $emailValidated : '';
+        $country = trim((string) ($_POST[$countryKey] ?? ''));
+        $phone = trim((string) ($_POST[$phoneKey] ?? ''));
+
+        if ($name === '' || $email === '' || $country === '' || $phone === '') {
+            $_SESSION['offplan_lead_error'] = 'Please fill in all required fields with valid details.';
+            header('Location: ' . $redirectUrl);
+            exit;
+        }
+
+        $name = mb_substr($name, 0, 150);
+        $email = mb_substr(strtolower($email), 0, 190);
+        $country = mb_substr($country, 0, 150);
+        $phone = mb_substr(preg_replace('/[^0-9+()\-\s]/', '', $phone), 0, 64);
+
+        $propertyTitleForLead = trim((string) ($property['property_title'] ?? ''));
+        if ($propertyTitleForLead === '') {
+            $propertyTitleForLead = trim((string) ($property['project_name'] ?? ''));
+        }
+
+        $normalizeBrochureUrl = static function (string $value): string {
+            $value = trim(str_replace('\\', '/', $value));
+            if ($value === '') {
+                return '';
+            }
+
+            if (preg_match('#^(https?:)?//#i', $value)) {
+                return $value;
+            }
+
+            return '/' . ltrim($value, '/');
+        };
+
+        $brochureUrl = '';
+        if ($formType === 'brochure') {
+            $brochureUrl = $normalizeBrochureUrl((string) ($_POST['brochure_url'] ?? ''));
+        }
+
+        $ipAddress = mb_substr((string) ($_SERVER['REMOTE_ADDR'] ?? ''), 0, 100);
+        $userAgent = mb_substr((string) ($_SERVER['HTTP_USER_AGENT'] ?? ''), 0, 500);
+
+        try {
+            $insert = $pdo->prepare(
+                'INSERT INTO offplan_leads '
+                . '(lead_type, property_id, property_title, name, email, phone, country, brochure_url, ip_address, user_agent, created_at) '
+                . 'VALUES (:lead_type, :property_id, :property_title, :name, :email, :phone, :country, :brochure_url, :ip_address, :user_agent, NOW())'
+            );
+
+            $insert->execute([
+                ':lead_type' => $formType,
+                ':property_id' => $propertyId,
+                ':property_title' => $propertyTitleForLead,
+                ':name' => $name,
+                ':email' => $email,
+                ':phone' => $phone,
+                ':country' => $country,
+                ':brochure_url' => $brochureUrl !== '' ? $brochureUrl : null,
+                ':ip_address' => $ipAddress !== '' ? $ipAddress : null,
+                ':user_agent' => $userAgent !== '' ? $userAgent : null,
+            ]);
+
+            if ($formType === 'brochure' && $brochureUrl !== '') {
+                $_SESSION['download_brochure_url'] = $brochureUrl;
+            }
+
+            header('Location: thankyou.php');
+            exit;
+        } catch (Throwable $e) {
+            error_log('Failed to save off-plan lead: ' . $e->getMessage());
+            $_SESSION['offplan_lead_error'] = 'We could not process your request at this time. Please try again later.';
+            header('Location: ' . $redirectUrl);
+            exit;
+        }
+    }
 }
 
 $decodeList = static function (?string $json): array {
@@ -379,6 +481,15 @@ $developerStats = array_values(array_filter([
 </head>
 
 <body>
+
+    <?php if ($leadFormError): ?>
+        <div class="container position-relative" style="z-index: 1050;">
+            <div class="alert alert-warning alert-dismissible fade show mt-3" role="alert">
+                <?= htmlspecialchars($leadFormError, ENT_QUOTES, 'UTF-8') ?>
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        </div>
+    <?php endif; ?>
 
 
     <!-- parent: .hh-property-hero -->
@@ -1500,10 +1611,12 @@ $developerStats = array_values(array_filter([
                 <p style="font-size: 14px !important; margin-bottom: 10px;">
                     Unlock expert advice, exclusive listings & investment insights.
                 </p>
-                <form method="POST" class="appointment-form" action="danuber">
+                <form method="POST" class="appointment-form"
+                    action="property-details.php?id=<?= (int) $propertyId ?>">
                     <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
                     <input type="hidden" name="property_title"
                         value="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                    <input type="hidden" name="form_type" value="popup">
                     <div class="form-group">
                         <label for="full_name">Enter Name</label>
                         <input type="text" name="name" id="full_name" class="form-control" required>
@@ -1548,10 +1661,12 @@ $developerStats = array_values(array_filter([
                 <p style="font-size: 14px !important; margin-bottom: 10px;">
                     Get your brochure instantly. Enter your details below to access the download.
                 </p>
-                <form method="POST" class="appointment-form" action="download-brochure">
+                <form method="POST" class="appointment-form"
+                    action="property-details.php?id=<?= (int) $propertyId ?>#downloadBrochure">
                     <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
                     <input type="hidden" name="property_title"
                         value="<?= htmlspecialchars($titleText, ENT_QUOTES, 'UTF-8') ?>">
+                    <input type="hidden" name="form_type" value="brochure">
                     <input type="hidden" name="brochure_url"
                         value="<?= htmlspecialchars($brochure, ENT_QUOTES, 'UTF-8') ?>">
                     <div class="form-group">

--- a/thankyou.php
+++ b/thankyou.php
@@ -1,3 +1,16 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/includes/config.php';
+
+hh_session_start();
+
+$downloadBrochureUrl = '';
+if (!empty($_SESSION['download_brochure_url'])) {
+    $downloadBrochureUrl = (string) $_SESSION['download_brochure_url'];
+    unset($_SESSION['download_brochure_url']);
+}
+?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -64,6 +77,24 @@
         </div>
     </div>
 
+    <?php if ($downloadBrochureUrl !== ''): ?>
+        <script>
+            window.addEventListener('DOMContentLoaded', function () {
+                var link = document.createElement('a');
+                link.href = <?= json_encode($downloadBrochureUrl, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?>;
+                link.download = '';
+                link.rel = 'noopener';
+                link.style.display = 'none';
+                document.body.appendChild(link);
+                link.click();
+                window.setTimeout(function () {
+                    if (link.parentNode) {
+                        link.parentNode.removeChild(link);
+                    }
+                }, 500);
+            });
+        </script>
+    <?php endif; ?>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- persist property popup and brochure enquiries into the `offplan_leads` table
- add automatic thank-you redirect with brochure download trigger and inline validation feedback
- introduce an admin Off-Plan Leads listing and update schema/navigation accordingly

## Testing
- php -l property-details.php
- php -l admin/offplan_leads.php
- php -l admin/includes/render.php
- php -l thankyou.php

------
https://chatgpt.com/codex/tasks/task_e_68e35a8b5128832a9c8ee1927bdf2a64