### PR TITLE
Fix brochure downloads and lead form routing

### DIFF
--- a/buy-properties-details.php
+++ b/buy-properties-details.php
@@ -237,6 +237,12 @@ $permitBarcode = is_string($property['permit_barcode'] ?? '') && $property['perm
 $videoLink = trim((string) ($property['video_link'] ?? ''));
 $locationMap = trim((string) ($property['location_map'] ?? ''));
 $brochure = trim((string) ($property['brochure'] ?? ''));
+if ($brochure !== '') {
+    $normalizedBrochure = $normalizeImagePath($brochure);
+    if ($normalizedBrochure !== null) {
+        $brochure = $normalizedBrochure;
+    }
+}
 
 $featureItems = array_values(array_filter([
     $property['project_status'] ?? null,
@@ -1515,7 +1521,7 @@ $developerStats = array_values(array_filter([
                 <p style="font-size: 14px !important; margin-bottom: 10px;">
                     Unlock expert advice, exclusive listings & investment insights.
                 </p>
-                <form method="POST" class="appointment-form" action="process_offplan_lead">
+                <form method="POST" class="appointment-form" action="process_offplan_lead.php">
                     <input type="hidden" name="redirect"
                         value="buy-properties-details.php?id=<?= (int) $propertyId ?>#propertyEnquirey">
                     <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">

--- a/property-details.php
+++ b/property-details.php
@@ -237,6 +237,12 @@ $permitBarcode = is_string($property['permit_barcode'] ?? '') && $property['perm
 $videoLink = trim((string) ($property['video_link'] ?? ''));
 $locationMap = trim((string) ($property['location_map'] ?? ''));
 $brochure = trim((string) ($property['brochure'] ?? ''));
+if ($brochure !== '') {
+    $normalizedBrochure = $normalizeImagePath($brochure);
+    if ($normalizedBrochure !== null) {
+        $brochure = $normalizedBrochure;
+    }
+}
 
 $featureItems = array_values(array_filter([
     $property['project_status'] ?? null,
@@ -1514,7 +1520,7 @@ $developerStats = array_values(array_filter([
                 <p style="font-size: 14px !important; margin-bottom: 10px;">
                     Unlock expert advice, exclusive listings & investment insights.
                 </p>
-                <form method="POST" class="appointment-form" action="process_offplan_lead">
+                <form method="POST" class="appointment-form" action="process_offplan_lead.php">
                     <input type="hidden" name="redirect"
                         value="property-details.php?id=<?= (int) $propertyId ?>#propertyEnquirey">
                     <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">
@@ -1565,7 +1571,7 @@ $developerStats = array_values(array_filter([
                 <p style="font-size: 14px !important; margin-bottom: 10px;">
                     Get your brochure instantly. Enter your details below to access the download.
                 </p>
-                <form method="POST" class="appointment-form" action="process_offplan_lead">
+                <form method="POST" class="appointment-form" action="process_offplan_lead.php">
                     <input type="hidden" name="redirect"
                         value="property-details.php?id=<?= (int) $propertyId ?>#downloadBrochure">
                     <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">

--- a/rent-properties-details.php
+++ b/rent-properties-details.php
@@ -237,6 +237,12 @@ $permitBarcode = is_string($property['permit_barcode'] ?? '') && $property['perm
 $videoLink = trim((string) ($property['video_link'] ?? ''));
 $locationMap = trim((string) ($property['location_map'] ?? ''));
 $brochure = trim((string) ($property['brochure'] ?? ''));
+if ($brochure !== '') {
+    $normalizedBrochure = $normalizeImagePath($brochure);
+    if ($normalizedBrochure !== null) {
+        $brochure = $normalizedBrochure;
+    }
+}
 
 $featureItems = array_values(array_filter([
     $property['project_status'] ?? null,
@@ -1515,7 +1521,7 @@ $developerStats = array_values(array_filter([
                 <p style="font-size: 14px !important; margin-bottom: 10px;">
                     Unlock expert advice, exclusive listings & investment insights.
                 </p>
-                <form method="POST" class="appointment-form" action="process_offplan_lead">
+                <form method="POST" class="appointment-form" action="process_offplan_lead.php">
                     <input type="hidden" name="redirect"
                         value="rent-properties-details.php?id=<?= (int) $propertyId ?>#propertyEnquirey">
                     <input type="hidden" name="property_id" value="<?= (int) $propertyId ?>">


### PR DESCRIPTION
## Summary
- normalize brochure file paths on property detail pages so brochure downloads point to uploaded files
- update register interest and brochure forms to submit to process_offplan_lead.php for consistent lead capture

## Testing
- php -l buy-properties-details.php
- php -l rent-properties-details.php
- php -l property-details.php

------
https://chatgpt.com/codex/tasks/task_e_68e3737cefcc832a8988e31fa1895c5c