### PR TITLE
Revamp property landmark cards

### DIFF
--- a/assets/css/properties.css
+++ b/assets/css/properties.css
@@ -2579,85 +2579,101 @@ p {
 }
 
 /* Landmarks list */
-/* .hh-location-01 .hh-location-01-landmarks {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 30px 8px;
-} */
-
-.hh-location-01 .hh-location-01-landmarks-head {
-    font-weight: 500;
-    margin-bottom: 8px;
-    color: #243533;
-}
-
-.hh-location-01 .hh-location-01-landmarks button {
-    width: 100%;
-    text-align: left;
-    background: #fff;
-    border: 1px solid #e6eceb;
-    border-radius: 12px;
-    padding: 15px 20px;
+.hh-location-01 .hh-location-01-landmarks {
+    background: #f5faf8;
+    border: 1px solid #dceae6;
+    border-radius: 18px;
+    padding: 24px;
     display: flex;
-    align-items: start;
-    justify-content: space-between;
-    gap: 0px;
-    cursor: pointer;
-    transition: box-shadow .2s ease, border-color .2s ease, transform .15s ease;
     flex-direction: column;
+    gap: 20px;
+    height: 100%;
 }
 
-.hh-location-01 .hh-location-01-landmarks button .right {
-    padding-left: 12px;
+.hh-location-01 .hh-landmarks-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
 }
 
-/* Mobile view: 1 column */
-@media (max-width: 767px) {
-    .hh-location-01 .hh-location-01-landmarks {
-        grid-template-columns: 1fr;
-    }
+.hh-landmark-card {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    background: #fff;
+    border: 1px solid #d6e7e3;
+    border-radius: 16px;
+    padding: 18px 20px;
+    transition: border-color .2s ease, box-shadow .2s ease, transform .2s ease;
 }
 
-.hh-location-01 .hh-location-01-landmarks button:hover {
-    border-color: #cfe7e3;
-    box-shadow: 0 8px 22px rgba(0, 0, 0, .06);
-    transform: translateY(-1px);
+.hh-landmark-card:hover {
+    border-color: #c1ded8;
+    box-shadow: 0 18px 34px -20px rgba(15, 160, 144, 0.7);
+    transform: translateY(-3px);
 }
 
-.hh-location-01 .hh-location-01-landmarks .left {
+.hh-landmark-icon {
+    width: 50px;
+    height: 50px;
+    border-radius: 14px;
+    background: #e9f6f3;
     display: flex;
     align-items: center;
-    gap: 0px;
-    position: relative;
-    right: 7px;
+    justify-content: center;
+    flex-shrink: 0;
 }
 
-.hh-location-01 .hh-location-01-landmarks .left .dot {
-    width: 20px;
+.hh-landmark-icon img {
+    width: 26px;
+    height: 26px;
     object-fit: contain;
 }
 
-.hh-location-01 .hh-location-01-landmarks .left b {
-    display: block;
-    font-size: 14px;
-    font-weight: 500;
+.hh-landmark-details {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
-
-
-.hh-location-01 .hh-location-01-landmarks .right em {
-    display: block;
-    font-style: normal;
-    color: #6c7a78;
-    font-size: 12px;
+.hh-landmark-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1c3b38;
 }
 
-.hh-location-01 .hh-location-01-landmarks .right a {
-    color: #0fa090;
-    text-decoration: none;
+.hh-landmark-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    color: #5f7b78;
+    font-size: 13px;
+}
+
+.hh-landmark-meta span {
+    display: inline-flex;
+    align-items: center;
+}
+
+.hh-landmark-meta-separator {
+    color: #b1c8c4;
     font-weight: 500;
-    font-size: 14px;
-    padding-left: 0px;
+    padding: 0 4px;
+}
+
+@media (max-width: 767px) {
+    .hh-location-01 .hh-location-01-landmarks {
+        padding: 20px;
+    }
+
+    .hh-location-01 .hh-landmarks-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .hh-landmark-card {
+        padding: 16px;
+    }
 }
 
 /* Side column */
@@ -3689,6 +3705,7 @@ body.no-scroll {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    gap: 24px;
 }
 
 @media only screen and (max-width:767px) {

--- a/property-details.php
+++ b/property-details.php
@@ -1137,29 +1137,75 @@ $developerStats = array_values(array_filter([
 
                         <!-- Landmarks list -->
                         <div class="col-12 col-md-6" id="LandMarkList">
-                            
+
                             <div class="hh-location-01-landmarks">
                                 <?php if ($locationAccess): ?>
-                                    <ul class="list-unstyled landmarks-list">
+                                    <?php
+                                    $landmarkIconKeywords = [
+                                        'mall' => 'assets/icons/community.svg',
+                                        'marina' => 'assets/icons/community.svg',
+                                        'airport' => 'assets/icons/globe.png',
+                                        'metro' => 'assets/icons/location.png',
+                                        'station' => 'assets/icons/location.png',
+                                        'school' => 'assets/icons/community.svg',
+                                        'hospital' => 'assets/icons/eye.svg',
+                                        'beach' => 'assets/icons/community.svg',
+                                        'park' => 'assets/icons/community.svg',
+                                        'tower' => 'assets/icons/home.svg',
+                                    ];
+                                    $defaultLandmarkIcon = 'assets/icons/location.png';
+                                    ?>
+                                    <div class="hh-landmarks-grid">
                                         <?php foreach ($locationAccess as $item): ?>
-                                            <li class="d-flex align-items-center mb-2">
-                                                <div class="d-flex align-items-center">
-                                                    <img class="dot me-2" src="assets/icons/dot-green.png" alt="">
-                                                    <span class="fw-semibold">
-                                                        <?= htmlspecialchars($item['landmark'], ENT_QUOTES, 'UTF-8') ?>
-                                                    </span>
+                                            <?php
+                                            $landmarkRaw = is_string($item['landmark']) ? $item['landmark'] : '';
+                                            $categoryRaw = is_string($item['category']) ? $item['category'] : '';
+                                            $distanceRaw = is_string($item['distance']) ? $item['distance'] : '';
+
+                                            $categoryValue = trim($categoryRaw);
+                                            $distanceValue = trim($distanceRaw);
+                                            $landmarkKey = strtolower($landmarkRaw);
+                                            $categoryKey = strtolower($categoryValue);
+
+                                            $iconPath = $defaultLandmarkIcon;
+                                            foreach ($landmarkIconKeywords as $keyword => $path) {
+                                                if (($categoryKey !== '' && str_contains($categoryKey, $keyword)) ||
+                                                    ($landmarkKey !== '' && str_contains($landmarkKey, $keyword))) {
+                                                    $iconPath = $path;
+                                                    break;
+                                                }
+                                            }
+
+                                            $metaParts = array_values(array_filter([
+                                                $distanceValue,
+                                                $categoryValue,
+                                            ], static fn($value): bool => $value !== ''));
+
+                                            $iconAlt = $categoryValue !== '' ? $categoryValue . ' icon' : 'Landmark icon';
+                                            ?>
+                                            <div class="hh-landmark-card">
+                                                <div class="hh-landmark-icon">
+                                                    <img src="<?= htmlspecialchars($iconPath, ENT_QUOTES, 'UTF-8') ?>"
+                                                        alt="<?= htmlspecialchars($iconAlt, ENT_QUOTES, 'UTF-8') ?>">
                                                 </div>
-                                                <div class="text-end">
-                                                    <?php if ($item['distance'] !== ''): ?>
-                                                        <span class="me-2"><?= htmlspecialchars($item['distance'], ENT_QUOTES, 'UTF-8') ?></span>
-                                                    <?php endif; ?>
-                                                    <?php if ($item['category'] !== ''): ?>
-                                                        <span class="text-white"><?= htmlspecialchars($item['category'], ENT_QUOTES, 'UTF-8') ?></span>
+                                                <div class="hh-landmark-details">
+                                                    <div class="hh-landmark-name">
+                                                        <?= htmlspecialchars($landmarkRaw, ENT_QUOTES, 'UTF-8') ?>
+                                                    </div>
+                                                    <?php if ($metaParts): ?>
+                                                        <div class="hh-landmark-meta">
+                                                            <?php foreach ($metaParts as $index => $metaPart): ?>
+                                                                <?php if ($index > 0): ?>
+                                                                    <span class="hh-landmark-meta-separator">|</span>
+                                                                <?php endif; ?>
+                                                                <span><?= htmlspecialchars($metaPart, ENT_QUOTES, 'UTF-8') ?></span>
+                                                            <?php endforeach; ?>
+                                                        </div>
                                                     <?php endif; ?>
                                                 </div>
-                                            </li>
+                                            </div>
                                         <?php endforeach; ?>
-                                    </ul>
+                                    </div>
                                 <?php else: ?>
                                     <p class="mb-0">Connectivity details will be available soon.</p>
                                 <?php endif; ?>


### PR DESCRIPTION
## Summary
- restyle the property details landmark list into a card-based grid with icon placeholders and meta separators
- add refreshed styling for the landmark cards, including hover states and responsive behavior, and adjust spacing around the column

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4c2e7b98c832a8b92512eb2c161e7